### PR TITLE
fix(s10): support atomic memory writes on Windows

### DIFF
--- a/s10_workspace_memory/README.md
+++ b/s10_workspace_memory/README.md
@@ -112,8 +112,10 @@ daily fact log ──select──> curated.json ──render──> MEMORY.md
 
 1. 写入完整内容；
 2. `flush + fsync`；
-3. `os.replace` 原子替换目标并 `fsync` 所在目录；
+3. `os.replace` 原子替换目标；支持目录句柄的平台继续 `fsync` 所在目录，Windows 则安全跳过不受 `os.open` 支持的目录同步；
 4. 失败时清理临时文件，旧版本保持不变。
+
+Windows 的回退仍会在替换前完整写入、刷新并同步临时文件，再执行同目录 `os.replace`，因此不会把半个新文件暴露为 canonical state。POSIX 平台额外同步目录项，以加强断电后的 rename 持久性。
 
 `curated.json` 是 canonical state，`MEMORY.md` 是可重建投影。如果进程在两次替换之间退出，下一次读取会以 canonical state 修复陈旧投影。新建一个 `WorkspaceMemory(project_dir)` 实例即可从磁盘恢复事实、策展条目和 prompt context；不会反序列化任何进程内对象。
 

--- a/s10_workspace_memory/code.py
+++ b/s10_workspace_memory/code.py
@@ -81,6 +81,25 @@ DEFAULT_RETENTION_DAYS = 30
 MAX_FACT_CHARS = 2_000
 MAX_CONTEXT_FACTS = 6
 WORKDIR = Path.cwd()
+_DIRECTORY_FSYNC_SUPPORTED = os.name != "nt"
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist a renamed directory entry where directory handles are supported.
+
+    POSIX platforms allow opening a directory and passing its descriptor to
+    ``fsync``.  Windows does not expose that operation through ``os.open``;
+    the temporary file has still been flushed and synced before ``os.replace``
+    makes the complete new version visible.
+    """
+
+    if not _DIRECTORY_FSYNC_SUPPORTED:
+        return
+    directory = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
 
 
 class MemoryErrorBase(RuntimeError):
@@ -376,12 +395,10 @@ class WorkspaceMemory:
             os.replace(temporary, path)
             # fsync the directory entry as well as the file contents.  Without
             # this step, a power loss may preserve the temporary file data but
-            # lose the rename that made it canonical.
-            directory = os.open(path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory)
-            finally:
-                os.close(directory)
+            # lose the rename that made it canonical.  Windows cannot open a
+            # directory through os.open, so its safe fallback stops after the
+            # synced temporary file and same-directory atomic replace.
+            _fsync_directory(path.parent)
         finally:
             temporary.unlink(missing_ok=True)
 

--- a/tests/test_workspace_memory.py
+++ b/tests/test_workspace_memory.py
@@ -130,6 +130,18 @@ def test_atomic_replace_preserves_previous_curated_file_on_failure(
     assert list(memory.memory_dir.glob(".*.tmp")) == []
 
 
+def test_directory_fsync_falls_back_without_opening_directory(
+    s10, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_if_opened(*_args, **_kwargs) -> None:
+        raise AssertionError("directory fsync fallback must not call os.open")
+
+    monkeypatch.setattr(s10, "_DIRECTORY_FSYNC_SUPPORTED", False)
+    monkeypatch.setattr(s10.os, "open", fail_if_opened)
+
+    s10._fsync_directory(tmp_path)
+
+
 def test_new_process_view_recovers_facts_and_curated_context(s10, tmp_path: Path) -> None:
     root = tmp_path / "project"
     writer = s10.WorkspaceMemory(root)


### PR DESCRIPTION
## Summary

- skip unsupported directory fsync on Windows while retaining file fsync plus same-directory atomic replace
- preserve POSIX directory fsync durability
- document platform semantics and add regression coverage

## Testing

- `python -m pytest -q tests/test_workspace_memory.py tests/test_user_memory.py tests/test_remote_memory.py` — 21 passed on Windows
- WSL POSIX atomic-write/recovery smoke — passed
- `python -m py_compile s10_workspace_memory/code.py tests/test_workspace_memory.py`
