### PR TITLE
feat(examples): add evaluated self-evolving skills loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ python3 s01_agent_loop/code.py --demo
 python3 s03_deferred_loading/code.py
 python3 s08_model_routing/code.py
 MINI_WORKBUDDY_HOME=.tmp/mini python3 examples/mini_workbuddy_demo/code.py --mode offline
+# 轨迹蒸馏 -> 评测 -> 人工批准 -> 版本化 Skill（完全离线）：
+python3 examples/self_evolving_skills/code.py --approve
 # 一次跑遍所有 harness 层（provider/session/记忆/权限/外部化/JSONL/HTTP/审计），产出 artifacts：
 python3 examples/full_tour/code.py
 python3 scripts/verify.py

--- a/docs/skill-evolution-and-evaluation.md
+++ b/docs/skill-evolution-and-evaluation.md
@@ -77,6 +77,11 @@ s16 的 `audit_skill()` 目前只扫 `rm -rf /`、`sudo`、`pip install` 这类
 4. **评测意识**：README 里引用上面 6 类基准，说明本项目技能子系统对标的是
    哪几维（Utility + Retrieval/Routing + Safety），比空泛说"好用"有说服力。
 
+保持 24 章主线不变的可运行版本见
+[`examples/self_evolving_skills/`](../examples/self_evolving_skills/)：它把成功 JSONL
+轨迹蒸馏成候选 `SKILL.md`，通过 held-out 回放、安全检查和显式人工审批后才进入
+版本化 Skill 库。
+
 ## 来源
 
 - *Agent Skill Evaluation and Evolution: Frameworks and Benchmarks*（综述）：

--- a/examples/self_evolving_skills/README.md
+++ b/examples/self_evolving_skills/README.md
@@ -1,0 +1,112 @@
+# Self-Evolving Skills 离线示例
+
+[返回首页](../../README.md)
+
+> Harness 层：模型权重保持不变，把成功执行轨迹蒸馏成可审查、可评测、可审批和可回滚的外部 Skill。
+
+## 代码架构图
+
+```mermaid
+flowchart LR
+    T["JSONL trajectories"] --> G["Triage gate"]
+    G --> D["Deterministic distillation"]
+    D --> C["Candidate SKILL.md"]
+    C --> E["Held-out replay + safety checks"]
+    E --> H{"Human approval?"}
+    H -->|No| Q["Keep candidate only"]
+    H -->|Yes| V["Versioned skill library"]
+    V --> A["Evolution audit"]
+```
+
+## 这个示例解决什么问题
+
+s09 已经能保存完整执行轨迹，s10 能从追加式事实中蒸馏长期记忆，s16 能加载和创建 `SKILL.md`，s23 能记录审计证据。本示例把这些思想连成一个部署期学习闭环：
+
+```text
+成功轨迹 -> 候选技能 -> 独立评测 -> 人工批准 -> 版本化发布
+```
+
+它不是让 Agent 无约束地改写自己的 Prompt 或源码，也不训练模型参数。Agent 的“进化”发生在外部、可读、可 diff、可回滚的 Skill 库中。
+
+## 安全与质量门禁
+
+候选 Skill 必须依次满足：
+
+1. 至少两条同类、成功且步骤一致的训练轨迹；
+2. 失败轨迹不能成为 Skill 来源；
+3. Skill 只保留通用意图、工具名和 provenance，不复制原始命令或工具输出；
+4. 声明的工具必须与实际轨迹一致；
+5. 一条未参与蒸馏的 held-out 轨迹必须成功复现相同步骤；
+6. 内容必须通过基础危险操作、密钥和提示覆盖扫描；
+7. 即使评测通过，没有显式 `approved_by` 也不能进入正式 Skill 库。
+
+字符串扫描只是第一层教学防线，不等于沙盒。真实系统仍需要声明式权限、隔离试跑、网络出口控制和更强的 Skill 安全评测。
+
+## 运行
+
+只生成候选并完成评测，在人工审批门前停止：
+
+```bash
+python3 examples/self_evolving_skills/code.py
+```
+
+模拟用户明确批准，将候选发布为版本化 Skill：
+
+```bash
+python3 examples/self_evolving_skills/code.py --approve --approved-by alice
+```
+
+指定隔离目录：
+
+```bash
+python3 examples/self_evolving_skills/code.py \
+  --home /tmp/learn-workbuddy-self-evolution \
+  --approve \
+  --approved-by alice
+```
+
+整个示例不需要 API key，也不会访问网络。
+
+## 产物结构
+
+```text
+.tmp/self-evolving-skills/
+├── traces/                         # 原始 JSONL 证据
+├── candidates/<candidate-id>/
+│   ├── candidate.json              # 结构化候选与 provenance
+│   ├── SKILL.md                    # 尚未发布的候选
+│   └── evaluation.json             # held-out 评测明细
+├── skills/python-test-validation/
+│   ├── manifest.json               # active_version + 历史版本
+│   └── v1/SKILL.md                 # 人工批准后的正式版本
+├── evolution-audit.jsonl           # 形成、评测、晋升事件
+└── run_manifest.json               # 本轮演示清单
+```
+
+重复批准同一个 candidate 是幂等的，不会制造重复版本；由新证据产生的新 candidate 才会进入下一版本。
+
+## 关键数据契约
+
+| 对象 | 作用 |
+|---|---|
+| `Trajectory` | 带 `trace_id`、任务族、train/validation split、结果和 SHA-256 来源摘要的证据 |
+| `SkillCandidate` | 由多条成功轨迹共同支持的候选步骤、工具权限和来源 ID |
+| `EvaluationReport` | 每一项门禁的布尔结果，不用一个模糊总分隐藏失败原因 |
+| `EvolutionStore` | 隔离保存证据、候选、评测、正式版本和审计事件 |
+| `SkillEvolutionPipeline` | triage、distill、evaluate；不拥有跳过人工审批的权限 |
+
+## 设计取舍
+
+- **确定性蒸馏**：教学版要求多条轨迹具有相同的高层步骤，再提取共同流程。以后可以替换为 LLM distiller，但输出契约和门禁不变。
+- **失败是教训，不是指令**：失败轨迹会被 triage 拒绝。后续可把它们写入独立的 pitfall/reflection memory，但不能直接发布成可执行 Skill。
+- **评测与训练分离**：held-out trace 不属于 `source_trace_ids`，避免拿训练证据证明自己。
+- **候选与发布分离**：通过评测只代表“可以提交审批”，不代表 Agent 有权安装。
+- **原始证据不进 Skill**：减少密钥、用户数据、绝对路径和一次性命令被永久固化的风险。
+
+## 验证
+
+```bash
+python3 -m pytest -q tests/test_self_evolving_skills.py
+```
+
+测试覆盖候选态停止、失败轨迹隔离、held-out 评测、显式审批、版本幂等和敏感轨迹拒绝。

--- a/examples/self_evolving_skills/code.py
+++ b/examples/self_evolving_skills/code.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Offline example: distill successful trajectories into reviewable skills.
+
+This example keeps model weights fixed.  The harness learns in external,
+inspectable state: successful JSONL trajectories become a candidate SKILL.md,
+which must pass held-out evaluation and receive explicit human approval before
+it enters the versioned skill library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+import yaml
+
+
+SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{1,63}$")
+SAFE_TOOL = re.compile(r"^[a-zA-Z0-9_.-]{1,64}$")
+BLOCKED_TEXT = (
+    "rm -rf",
+    "sudo ",
+    "curl ",
+    "invoke-webrequest",
+    "ignore previous",
+    "authorization:",
+    "api_key",
+    "token=",
+    "secret=",
+)
+
+
+class EvolutionError(RuntimeError):
+    """Raised when evidence, evaluation, or promotion violates a gate."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _contains_blocked_text(value: str) -> str | None:
+    lowered = value.casefold()
+    return next((pattern for pattern in BLOCKED_TEXT if pattern in lowered), None)
+
+
+def _validate_id(value: object, *, field_name: str) -> str:
+    normalized = str(value).strip().casefold()
+    if not SAFE_ID.fullmatch(normalized):
+        raise EvolutionError(f"{field_name} must match {SAFE_ID.pattern}")
+    return normalized
+
+
+def _validate_text(value: object, *, field_name: str, max_chars: int = 500) -> str:
+    normalized = " ".join(str(value).split())
+    if not normalized:
+        raise EvolutionError(f"{field_name} must not be empty")
+    if len(normalized) > max_chars:
+        raise EvolutionError(f"{field_name} exceeds {max_chars} characters")
+    blocked = _contains_blocked_text(normalized)
+    if blocked:
+        raise EvolutionError(f"{field_name} contains blocked text: {blocked}")
+    return normalized
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Expose either the old file or the complete new file, never a partial one."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+@dataclass(frozen=True)
+class StepEvidence:
+    intent: str
+    tool: str
+    ok: bool
+
+    @property
+    def signature(self) -> tuple[str, str]:
+        return (self.intent.casefold(), self.tool)
+
+
+@dataclass(frozen=True)
+class Trajectory:
+    trace_id: str
+    task_family: str
+    task: str
+    split: str
+    outcome: str
+    steps: tuple[StepEvidence, ...]
+    source_digest: str
+
+    @property
+    def successful(self) -> bool:
+        return (
+            self.outcome == "success"
+            and bool(self.steps)
+            and all(step.ok for step in self.steps)
+        )
+
+    @property
+    def signature(self) -> tuple[tuple[str, str], ...]:
+        return tuple(step.signature for step in self.steps)
+
+
+@dataclass(frozen=True)
+class SkillCandidate:
+    candidate_id: str
+    title: str
+    summary: str
+    read_when: tuple[str, ...]
+    steps: tuple[StepEvidence, ...]
+    required_tools: tuple[str, ...]
+    source_trace_ids: tuple[str, ...]
+    source_digests: tuple[str, ...]
+    created_at: str
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["steps"] = [asdict(step) for step in self.steps]
+        return payload
+
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    candidate_id: str
+    validation_trace_id: str
+    checks: Mapping[str, bool]
+    passed: bool
+    evaluated_at: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "validation_trace_id": self.validation_trace_id,
+            "checks": dict(self.checks),
+            "passed": self.passed,
+            "evaluated_at": self.evaluated_at,
+        }
+
+
+class EvolutionStore:
+    """Filesystem boundary for evidence, candidates, evaluations, and releases."""
+
+    def __init__(self, root: Path):
+        self.root = root.expanduser().resolve()
+        self.traces_dir = self.root / "traces"
+        self.candidates_dir = self.root / "candidates"
+        self.skills_dir = self.root / "skills"
+        self.audit_path = self.root / "evolution-audit.jsonl"
+        for directory in (self.traces_dir, self.candidates_dir, self.skills_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+    def append_audit(self, action: str, details: Mapping[str, object]) -> None:
+        event = {"timestamp": _utc_now(), "action": action, "details": dict(details)}
+        with self.audit_path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(json.dumps(event, sort_keys=True, ensure_ascii=False) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def write_trajectory(
+        self,
+        *,
+        trace_id: str,
+        task_family: str,
+        task: str,
+        split: str,
+        outcome: str,
+        steps: Sequence[Mapping[str, object]],
+    ) -> Path:
+        safe_trace_id = _validate_id(trace_id, field_name="trace_id")
+        path = self.traces_dir / f"{safe_trace_id}.jsonl"
+        records = [
+            {
+                "type": "trajectory",
+                "trace_id": safe_trace_id,
+                "task_family": _validate_id(task_family, field_name="task_family"),
+                "task": _validate_text(task, field_name="task"),
+                "split": split,
+                "outcome": outcome,
+            }
+        ]
+        records.extend({"type": "step", **dict(step)} for step in steps)
+        rendered = "".join(
+            json.dumps(record, sort_keys=True, ensure_ascii=False) + "\n" for record in records
+        )
+        if blocked := _contains_blocked_text(rendered):
+            raise EvolutionError(f"trajectory contains blocked text: {blocked}")
+        _atomic_write_text(path, rendered)
+        self.append_audit("trajectory_written", {"trace_id": safe_trace_id, "path": str(path)})
+        return path
+
+    def load_trajectory(self, path: Path) -> Trajectory:
+        raw = path.read_bytes()
+        text = raw.decode("utf-8")
+        if blocked := _contains_blocked_text(text):
+            raise EvolutionError(f"trajectory contains blocked text: {blocked}")
+        try:
+            records = [json.loads(line) for line in text.splitlines() if line.strip()]
+        except json.JSONDecodeError as exc:
+            raise EvolutionError(f"invalid trajectory JSONL: {path.name}") from exc
+        if not records or records[0].get("type") != "trajectory":
+            raise EvolutionError("trajectory must start with a metadata record")
+
+        header = records[0]
+        split = str(header.get("split", ""))
+        outcome = str(header.get("outcome", ""))
+        if split not in {"train", "validation"}:
+            raise EvolutionError("trajectory split must be train or validation")
+        if outcome not in {"success", "failure"}:
+            raise EvolutionError("trajectory outcome must be success or failure")
+
+        steps: list[StepEvidence] = []
+        for index, record in enumerate(records[1:], start=2):
+            if record.get("type") != "step":
+                raise EvolutionError(f"line {index} must be a step record")
+            tool = str(record.get("tool", "")).strip()
+            if not SAFE_TOOL.fullmatch(tool):
+                raise EvolutionError(f"line {index} has invalid tool name")
+            steps.append(
+                StepEvidence(
+                    intent=_validate_text(
+                        record.get("intent", ""),
+                        field_name=f"line {index} intent",
+                    ),
+                    tool=tool,
+                    ok=record.get("ok") is True,
+                )
+            )
+
+        return Trajectory(
+            trace_id=_validate_id(header.get("trace_id"), field_name="trace_id"),
+            task_family=_validate_id(header.get("task_family"), field_name="task_family"),
+            task=_validate_text(header.get("task"), field_name="task"),
+            split=split,
+            outcome=outcome,
+            steps=tuple(steps),
+            source_digest=hashlib.sha256(raw).hexdigest(),
+        )
+
+    def candidate_dir(self, candidate_id: str) -> Path:
+        return self.candidates_dir / _validate_id(candidate_id, field_name="candidate_id")
+
+    def save_candidate(self, candidate: SkillCandidate) -> Path:
+        directory = self.candidate_dir(candidate.candidate_id)
+        _atomic_write_text(
+            directory / "candidate.json",
+            json.dumps(candidate.to_dict(), indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        )
+        draft = render_skill(candidate, status="candidate")
+        _atomic_write_text(directory / "SKILL.md", draft)
+        self.append_audit(
+            "candidate_created",
+            {
+                "candidate_id": candidate.candidate_id,
+                "source_trace_ids": candidate.source_trace_ids,
+            },
+        )
+        return directory / "SKILL.md"
+
+    def save_evaluation(self, report: EvaluationReport) -> Path:
+        path = self.candidate_dir(report.candidate_id) / "evaluation.json"
+        _atomic_write_text(
+            path,
+            json.dumps(report.to_dict(), indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        )
+        self.append_audit(
+            "candidate_evaluated",
+            {"candidate_id": report.candidate_id, "passed": report.passed},
+        )
+        return path
+
+    def promote(
+        self,
+        candidate: SkillCandidate,
+        report: EvaluationReport,
+        *,
+        approved_by: str,
+    ) -> Path:
+        if not approved_by.strip():
+            raise EvolutionError("explicit approved_by is required")
+        approver = _validate_text(approved_by, field_name="approved_by", max_chars=100)
+        if (
+            report.candidate_id != candidate.candidate_id
+            or not report.passed
+            or not report.checks
+            or not all(report.checks.values())
+        ):
+            raise EvolutionError("candidate must have a matching passing evaluation")
+
+        evaluation_path = self.candidate_dir(candidate.candidate_id) / "evaluation.json"
+        if not evaluation_path.exists():
+            raise EvolutionError("candidate has no stored evaluation evidence")
+        stored_report = json.loads(evaluation_path.read_text(encoding="utf-8"))
+        if stored_report != report.to_dict():
+            raise EvolutionError("stored evaluation does not match the promotion request")
+
+        skill_root = self.skills_dir / candidate.title
+        manifest_path = skill_root / "manifest.json"
+        if manifest_path.exists():
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        else:
+            manifest = {"title": candidate.title, "active_version": None, "history": []}
+
+        for item in manifest["history"]:
+            if item["candidate_id"] == candidate.candidate_id:
+                return skill_root / f"v{item['version']}" / "SKILL.md"
+
+        version = len(manifest["history"]) + 1
+        release_path = skill_root / f"v{version}" / "SKILL.md"
+        _atomic_write_text(
+            release_path,
+            render_skill(
+                candidate,
+                status="approved",
+                version=version,
+                approved_by=approver,
+            ),
+        )
+        manifest["active_version"] = version
+        manifest["history"].append(
+            {
+                "version": version,
+                "candidate_id": candidate.candidate_id,
+                "approved_by": approver,
+                "approved_at": _utc_now(),
+                "path": str(release_path),
+            }
+        )
+        _atomic_write_text(
+            manifest_path,
+            json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        )
+        self.append_audit(
+            "skill_promoted",
+            {
+                "candidate_id": candidate.candidate_id,
+                "title": candidate.title,
+                "version": version,
+                "approved_by": approver,
+            },
+        )
+        return release_path
+
+
+class SkillEvolutionPipeline:
+    """Deterministic trajectory distillation with evaluation and approval gates."""
+
+    def __init__(self, store: EvolutionStore, *, minimum_support: int = 2):
+        if minimum_support < 2:
+            raise ValueError("minimum_support must be at least 2")
+        self.store = store
+        self.minimum_support = minimum_support
+
+    def triage(
+        self, trajectories: Iterable[Trajectory], *, task_family: str
+    ) -> tuple[list[Trajectory], dict[str, str]]:
+        family = _validate_id(task_family, field_name="task_family")
+        accepted: list[Trajectory] = []
+        rejected: dict[str, str] = {}
+        for trajectory in trajectories:
+            reason: str | None = None
+            if trajectory.task_family != family:
+                reason = "different task family"
+            elif trajectory.split != "train":
+                reason = "held-out validation evidence"
+            elif not trajectory.successful:
+                reason = "trajectory did not complete successfully"
+            if reason:
+                rejected[trajectory.trace_id] = reason
+            else:
+                accepted.append(trajectory)
+        return sorted(accepted, key=lambda item: item.trace_id), rejected
+
+    def distill(self, trajectories: Sequence[Trajectory], *, task_family: str) -> SkillCandidate:
+        if len(trajectories) < self.minimum_support:
+            raise EvolutionError(
+                f"need at least {self.minimum_support} successful training trajectories"
+            )
+        if len({item.trace_id for item in trajectories}) != len(trajectories):
+            raise EvolutionError("minimum support requires distinct trajectory IDs")
+        expected = trajectories[0].signature
+        if not expected or any(item.signature != expected for item in trajectories[1:]):
+            raise EvolutionError("successful trajectories do not share one stable procedure")
+
+        family = _validate_id(task_family, field_name="task_family")
+        if any(
+            item.task_family != family or item.split != "train" or not item.successful
+            for item in trajectories
+        ):
+            raise EvolutionError("distillation received ineligible evidence")
+
+        source_ids = tuple(sorted(item.trace_id for item in trajectories))
+        source_digests = tuple(
+            item.source_digest for item in sorted(trajectories, key=lambda item: item.trace_id)
+        )
+        candidate_seed = json.dumps(
+            {"family": family, "source_ids": source_ids, "signature": expected},
+            sort_keys=True,
+        )
+        candidate_hash = hashlib.sha256(candidate_seed.encode("utf-8")).hexdigest()
+        candidate_id = "candidate-" + candidate_hash[:16]
+        tools = tuple(sorted({step.tool for step in trajectories[0].steps}))
+        tokens = tuple(part for part in family.split("-") if len(part) >= 4)
+        candidate = SkillCandidate(
+            candidate_id=candidate_id,
+            title=family,
+            summary=(
+                f"Reusable {family.replace('-', ' ')} procedure distilled from successful runs."
+            ),
+            read_when=(family.replace("-", " "),) + tokens,
+            steps=trajectories[0].steps,
+            required_tools=tools,
+            source_trace_ids=source_ids,
+            source_digests=source_digests,
+            created_at=_utc_now(),
+        )
+        self.store.save_candidate(candidate)
+        return candidate
+
+    def evaluate(
+        self, candidate: SkillCandidate, *, validation: Trajectory
+    ) -> EvaluationReport:
+        candidate_text = render_skill(candidate, status="candidate")
+        observed_tools = tuple(sorted({step.tool for step in candidate.steps}))
+        checks = {
+            "minimum_support": len(candidate.source_trace_ids) >= self.minimum_support,
+            "held_out_trace": validation.trace_id not in candidate.source_trace_ids,
+            "held_out_digest": validation.source_digest not in candidate.source_digests,
+            "same_task_family": validation.task_family == candidate.title,
+            "validation_succeeded": validation.split == "validation" and validation.successful,
+            "procedure_replayed": validation.signature
+            == tuple(step.signature for step in candidate.steps),
+            "declared_tools_match": candidate.required_tools == observed_tools
+            == tuple(sorted({step.tool for step in validation.steps})),
+            "content_safety_scan": _contains_blocked_text(candidate_text) is None,
+        }
+        report = EvaluationReport(
+            candidate_id=candidate.candidate_id,
+            validation_trace_id=validation.trace_id,
+            checks=checks,
+            passed=all(checks.values()),
+            evaluated_at=_utc_now(),
+        )
+        self.store.save_evaluation(report)
+        return report
+
+
+def render_skill(
+    candidate: SkillCandidate,
+    *,
+    status: str,
+    version: int | None = None,
+    approved_by: str | None = None,
+) -> str:
+    frontmatter: dict[str, object] = {
+        "title": candidate.title,
+        "summary": candidate.summary,
+        "read_when": list(candidate.read_when),
+        "agent_created": True,
+        "status": status,
+        "required_tools": list(candidate.required_tools),
+        "source_trace_ids": list(candidate.source_trace_ids),
+    }
+    if version is not None:
+        frontmatter["version"] = version
+    if approved_by is not None:
+        frontmatter["approved_by"] = approved_by
+
+    heading = candidate.title.replace("-", " ").title()
+    lines = [
+        "---",
+        yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip(),
+        "---",
+        "",
+        f"# {heading}",
+        "",
+        (
+            "> Generated from successful execution evidence. Review provenance and "
+            "permissions before use."
+        ),
+        "",
+        "## Procedure",
+        "",
+    ]
+    for index, step in enumerate(candidate.steps, start=1):
+        lines.append(
+            f"{index}. {step.intent} Use `{step.tool}` through the harness permission gate."
+        )
+    lines.extend(
+        [
+            "",
+            "## Evidence boundary",
+            "",
+            f"- Support: {len(candidate.source_trace_ids)} successful trajectories.",
+            "- Raw commands and tool outputs stay in the source traces; they are not copied here.",
+            "- A passing held-out replay and explicit human approval are required for promotion.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def seed_demo_trajectories(store: EvolutionStore) -> list[Trajectory]:
+    shared_steps = [
+        {"intent": "Inspect the project test configuration.", "tool": "read_file", "ok": True},
+        {"intent": "Run the smallest relevant test target.", "tool": "bash", "ok": True},
+        {"intent": "Record the verification result for review.", "tool": "bash", "ok": True},
+    ]
+    specs = [
+        ("train-run-1", "train", "success", shared_steps),
+        ("train-run-2", "train", "success", shared_steps),
+        ("validation-run-1", "validation", "success", shared_steps),
+        (
+            "failed-run-1",
+            "train",
+            "failure",
+            [
+                {
+                    "intent": "Run tests before inspecting configuration.",
+                    "tool": "bash",
+                    "ok": False,
+                }
+            ],
+        ),
+    ]
+    paths = [
+        store.write_trajectory(
+            trace_id=trace_id,
+            task_family="python-test-validation",
+            task="Validate a Python change with focused tests and recorded evidence.",
+            split=split,
+            outcome=outcome,
+            steps=steps,
+        )
+        for trace_id, split, outcome, steps in specs
+    ]
+    return [store.load_trajectory(path) for path in paths]
+
+
+def run_demo(home: Path, *, approve: bool = False, approved_by: str = "demo-user") -> dict:
+    store = EvolutionStore(home)
+    pipeline = SkillEvolutionPipeline(store)
+    trajectories = seed_demo_trajectories(store)
+    training, rejected = pipeline.triage(
+        trajectories,
+        task_family="python-test-validation",
+    )
+    candidate = pipeline.distill(training, task_family="python-test-validation")
+    validation = next(item for item in trajectories if item.split == "validation")
+    report = pipeline.evaluate(candidate, validation=validation)
+    promoted_path = (
+        store.promote(candidate, report, approved_by=approved_by) if approve else None
+    )
+    manifest = {
+        "home": str(store.root),
+        "candidate_id": candidate.candidate_id,
+        "candidate_path": str(store.candidate_dir(candidate.candidate_id) / "SKILL.md"),
+        "evaluation_path": str(store.candidate_dir(candidate.candidate_id) / "evaluation.json"),
+        "evaluation_passed": report.passed,
+        "source_trace_ids": list(candidate.source_trace_ids),
+        "validation_trace_id": validation.trace_id,
+        "rejected_traces": rejected,
+        "promotion_requested": approve,
+        "promoted_skill_path": str(promoted_path) if promoted_path else None,
+        "audit_path": str(store.audit_path),
+    }
+    _atomic_write_text(
+        store.root / "run_manifest.json",
+        json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+    )
+    return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Distill successful trajectories into an evaluated, reviewable skill candidate."
+        )
+    )
+    parser.add_argument(
+        "--home",
+        type=Path,
+        default=Path(".tmp/self-evolving-skills"),
+        help="artifact directory (default: .tmp/self-evolving-skills)",
+    )
+    parser.add_argument(
+        "--approve",
+        action="store_true",
+        help="simulate explicit human approval after the evaluation passes",
+    )
+    parser.add_argument(
+        "--approved-by",
+        default="demo-user",
+        help="identity recorded when --approve is supplied",
+    )
+    args = parser.parse_args()
+    manifest = run_demo(args.home, approve=args.approve, approved_by=args.approved_by)
+
+    print("Self-evolving skills demo")
+    print("Home:", manifest["home"])
+    print("Candidate:", manifest["candidate_path"])
+    print("Source traces:", ", ".join(manifest["source_trace_ids"]))
+    print("Rejected traces:", json.dumps(manifest["rejected_traces"], ensure_ascii=False))
+    print("Held-out evaluation passed:", manifest["evaluation_passed"])
+    if manifest["promoted_skill_path"]:
+        print("Approved skill:", manifest["promoted_skill_path"])
+    else:
+        print("Promotion: stopped at the human approval gate (use --approve to continue)")
+    print("Audit:", manifest["audit_path"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_self_evolving_skills.py
+++ b/tests/test_self_evolving_skills.py
@@ -1,0 +1,193 @@
+"""Offline contracts for the trajectory-to-skill evolution example."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def evolution():
+    module_name = "self_evolving_skills_test_module"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        ROOT / "examples" / "self_evolving_skills" / "code.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    try:
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    return yaml.safe_load(text.split("---", 2)[1])
+
+
+def _prepared(evolution, tmp_path: Path):
+    store = evolution.EvolutionStore(tmp_path / "evolution")
+    pipeline = evolution.SkillEvolutionPipeline(store)
+    trajectories = evolution.seed_demo_trajectories(store)
+    training, rejected = pipeline.triage(
+        trajectories,
+        task_family="python-test-validation",
+    )
+    candidate = pipeline.distill(training, task_family="python-test-validation")
+    validation = next(item for item in trajectories if item.split == "validation")
+    report = pipeline.evaluate(candidate, validation=validation)
+    return store, candidate, report, rejected
+
+
+def test_demo_stops_at_human_gate_and_excludes_failed_evidence(
+    evolution, tmp_path: Path
+) -> None:
+    manifest = evolution.run_demo(tmp_path / "candidate-only", approve=False)
+
+    assert manifest["evaluation_passed"] is True
+    assert manifest["promoted_skill_path"] is None
+    assert manifest["source_trace_ids"] == ["train-run-1", "train-run-2"]
+    assert manifest["rejected_traces"]["failed-run-1"] == (
+        "trajectory did not complete successfully"
+    )
+    assert manifest["rejected_traces"]["validation-run-1"] == (
+        "held-out validation evidence"
+    )
+    assert Path(manifest["candidate_path"]).exists()
+    assert Path(manifest["evaluation_path"]).exists()
+    assert list((tmp_path / "candidate-only" / "skills").rglob("SKILL.md")) == []
+
+
+def test_explicit_approval_promotes_a_versioned_provenance_bearing_skill(
+    evolution, tmp_path: Path
+) -> None:
+    manifest = evolution.run_demo(
+        tmp_path / "approved",
+        approve=True,
+        approved_by="alice",
+    )
+    skill_path = Path(manifest["promoted_skill_path"])
+    metadata = _frontmatter(skill_path)
+
+    assert skill_path.as_posix().endswith("skills/python-test-validation/v1/SKILL.md")
+    assert metadata["status"] == "approved"
+    assert metadata["version"] == 1
+    assert metadata["approved_by"] == "alice"
+    assert metadata["required_tools"] == ["bash", "read_file"]
+    assert metadata["source_trace_ids"] == ["train-run-1", "train-run-2"]
+
+    library_manifest = json.loads(
+        skill_path.parents[1].joinpath("manifest.json").read_text(encoding="utf-8")
+    )
+    assert library_manifest["active_version"] == 1
+    assert len(library_manifest["history"]) == 1
+
+
+def test_promotion_requires_matching_evaluation_and_explicit_approver(
+    evolution, tmp_path: Path
+) -> None:
+    store, candidate, report, _ = _prepared(evolution, tmp_path)
+
+    with pytest.raises(evolution.EvolutionError, match="approved_by"):
+        store.promote(candidate, report, approved_by="")
+
+    failed_report = replace(report, passed=False)
+    with pytest.raises(evolution.EvolutionError, match="passing evaluation"):
+        store.promote(candidate, failed_report, approved_by="alice")
+
+    forged_report = replace(report, validation_trace_id="forged-validation")
+    with pytest.raises(evolution.EvolutionError, match="stored evaluation"):
+        store.promote(candidate, forged_report, approved_by="alice")
+
+
+def test_repeated_promotion_is_idempotent(evolution, tmp_path: Path) -> None:
+    store, candidate, report, _ = _prepared(evolution, tmp_path)
+
+    first = store.promote(candidate, report, approved_by="alice")
+    second = store.promote(candidate, report, approved_by="alice")
+    manifest = json.loads(first.parents[1].joinpath("manifest.json").read_text(encoding="utf-8"))
+
+    assert second == first
+    assert len(manifest["history"]) == 1
+    assert list(first.parents[1].glob("v*/SKILL.md")) == [first]
+
+
+def test_distillation_requires_distinct_supporting_trajectories(
+    evolution, tmp_path: Path
+) -> None:
+    store = evolution.EvolutionStore(tmp_path / "duplicates")
+    pipeline = evolution.SkillEvolutionPipeline(store)
+    trajectories = evolution.seed_demo_trajectories(store)
+    training, _ = pipeline.triage(trajectories, task_family="python-test-validation")
+
+    with pytest.raises(evolution.EvolutionError, match="distinct trajectory IDs"):
+        pipeline.distill(
+            [training[0], training[0]],
+            task_family="python-test-validation",
+        )
+
+    validation = next(item for item in trajectories if item.split == "validation")
+    with pytest.raises(evolution.EvolutionError, match="ineligible evidence"):
+        pipeline.distill(
+            [training[0], validation],
+            task_family="python-test-validation",
+        )
+
+
+def test_secret_bearing_external_trajectory_is_rejected(
+    evolution, tmp_path: Path
+) -> None:
+    store = evolution.EvolutionStore(tmp_path / "unsafe")
+    unsafe = store.traces_dir / "unsafe-run.jsonl"
+    unsafe.write_text(
+        """{"type":"trajectory","trace_id":"unsafe-run",\
+"task_family":"python-test-validation","task":"validate",\
+"split":"train","outcome":"success"}
+{"type":"step","intent":"Use token=private-value","tool":"bash","ok":true}
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(evolution.EvolutionError, match="blocked text"):
+        store.load_trajectory(unsafe)
+
+
+def test_cli_offline_demo_writes_manifest(evolution, tmp_path: Path) -> None:
+    home = tmp_path / "cli-home"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "examples/self_evolving_skills/code.py",
+            "--home",
+            str(home),
+            "--approve",
+            "--approved-by",
+            "test-user",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout
+    manifest = json.loads((home / "run_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["evaluation_passed"] is True
+    assert Path(manifest["promoted_skill_path"]).exists()
+    assert "Held-out evaluation passed: True" in result.stdout


### PR DESCRIPTION
## Summary

- add a fully offline trajectory → candidate `SKILL.md` → held-out evaluation → human approval → versioned release example
- exclude failed and validation traces from training, retain provenance, and check declared tools plus unsafe content
- add documentation and seven contract tests while keeping the 24 chapters and 27 existing images unchanged

## Testing

- `python -m pytest -q tests/test_self_evolving_skills.py` — 7 passed
- `python -m pytest -q tests/test_self_evolving_skills.py tests/test_jsonl_transcript.py tests/test_chapter_imports.py` — 16 passed
- Windows and WSL offline CLI smoke — passed
- structure check — 24 chapters, 27 images, all 28 READMEs include Mermaid architecture diagrams
