### PR TITLE
feat(skills): enforce declarative permissions

### DIFF
--- a/docs/skill-evolution-and-evaluation.md
+++ b/docs/skill-evolution-and-evaluation.md
@@ -45,9 +45,9 @@ P0/P1/P2 检查，但那套字符串匹配还远不够，见下一节。
 
 ## 三、SKILL-INJECT：三类技能注入攻击
 
-s16 的 `audit_skill()` 目前只扫 `rm -rf /`、`sudo`、`pip install` 这类
-**直白模式**。综述里的 SKILL-INJECT 基准指出恶意技能有三类更隐蔽的攻击
-面，纯字符串黑名单一个都拦不住：
+s16 的 `audit_skill()` 保留 `rm -rf /`、`sudo`、`pip install` 这类直白模式
+扫描，同时新增严格的声明式权限解析、权限升级 diff 与运行时门禁。但模式扫描本身
+仍拦不住综述中 SKILL-INJECT 的三类隐蔽攻击：
 
 1. **隐藏覆盖 (hidden override)**：技能表面人畜无害，实际悄悄覆盖或重定义
    了 harness 的默认行为/安全规则。对应"压缩整合"范式删掉安全规则的风险。
@@ -68,12 +68,13 @@ s16 的 `audit_skill()` 目前只扫 `rm -rf /`、`sudo`、`pip install` 这类
 
 1. **给 s16 的 `audit_skill` 补三类攻击的说明与检测占位**（已在 s16 README
    补充），让读者知道 P0/P1/P2 只是第一层。
-2. **s16/s17 增加"声明式权限"字段**：技能在 frontmatter 里声明它需要哪些
-   工具/网络/路径，加载时和实际行为做 diff，这是拦"隐藏覆盖"和"伪装转移"
-   最实用的手段。
-3. **未来的自进化章节**：如果加第 25 章，优先做"轨迹蒸馏 → 新技能"，因为它
-   纯 harness 可实现、演示效果好（用户重复任务被自动固化），且是 Hermes 那
-   类"自进化 Agent"卖点的教学版。
+2. **s16/s17 增加"声明式权限"字段**（已落地）：技能在 frontmatter 里声明
+   工具/网络/路径；未知字段和越界路径 fail closed，新旧版本生成权限升级 diff，
+   s17 在 `ToolSearch` 与 `DeferExecuteTool` 两阶段都执行 Connector trust 与
+   Skill grant 的交集校验。
+3. **轨迹蒸馏 → 新技能**（已在 example 落地）：保持 24 章主线不变，用
+   `examples/self_evolving_skills/` 演示重复成功轨迹、held-out 回放、安全检查和
+   人工审批后的版本化发布。
 4. **评测意识**：README 里引用上面 6 类基准，说明本项目技能子系统对标的是
    哪几维（Utility + Retrieval/Routing + Safety），比空泛说"好用"有说服力。
 

--- a/s16_skills_system/README.md
+++ b/s16_skills_system/README.md
@@ -1,6 +1,6 @@
 # s16: Skills System — 技能先列目录, 用到时再展开
 
-> *"技能先列目录, 用到时再展开"* — SKILL.md frontmatter, 按需加载。
+> *"技能先列目录, 用到时再展开"* — SKILL.md frontmatter, 按需加载，权限显式声明。
 >
 > **Harness 层**: 扩展生态 — agent 的知识按需加载。
 
@@ -14,8 +14,13 @@
 flowchart LR
     A["Skill Directory"] --> B["Skill Search"]
     B --> C["Skill Loader"]
-    C --> D["Prompt/Tools Merge"]
-    D --> E["Agent Capability"]
+    C --> P["Permission Manifest"]
+    C --> D["Prompt Merge"]
+    P --> G{"Policy Gate"}
+    H["Harness Permission Ceiling"] --> G
+    D --> E["Agent Tool Call"] --> G
+    G -->|Allow| X["Tool Dispatch"]
+    G -->|Deny| Y["Permission Error"]
     C -. "state" .-> S["runtime state"]
     S -. "recover" .-> C
 ```
@@ -37,13 +42,14 @@ flowchart LR
 - 把所有 skill 全文注入 prompt, 会浪费上下文。
 - Skill 写成泛泛建议, 模型不知道什么时候触发。
 - 脚本和参考资料没有边界, 会让 skill 难以复用。
+- 把 Connector 信任或 Skill 声明误当成授权；它们都不能突破 Harness 的基础权限。
 ## 问题
 
 agent 有基础工具（bash、read、write），有记忆系统，有身份。但不同任务需要不同的**操作指南**——提交代码有 commit 规范，做 code review 有 review 流程，部署有部署检查清单。如果把这些全部塞进系统提示，提示会膨胀到不可接受。
 
 你需要一种机制：**平时只列技能目录（名字 + 什么时候用），用到时才加载完整内容。** 就像人的知识——你知道图书馆里有哪些书（目录），但只有需要时才去翻开具体那本。
 
-WorkBuddy 的 Skills 系统解决这个问题。每个技能是一个目录，包含一个 `SKILL.md` 文件。`SKILL.md` 的头部有 YAML frontmatter——标题、摘要、触发条件。系统启动时只扫描 frontmatter 建索引，不加载全文。当用户的输入匹配触发条件时，才把对应技能的完整内容加载进上下文。
+WorkBuddy 的 Skills 系统解决这个问题。每个技能是一个目录，包含一个 `SKILL.md` 文件。`SKILL.md` 的头部有 YAML frontmatter——标题、摘要、触发条件和权限声明。系统启动时只扫描 frontmatter 建索引，不加载全文。当用户的输入匹配触发条件时，才把对应技能的完整内容加载进上下文；其工具调用还必须同时通过 Skill manifest 与 Harness 基础权限。
 
 ---
 
@@ -114,6 +120,12 @@ read_when:
   - git push
   - 保存修改
 agent_created: false
+permissions:
+  tools: [bash]
+  network: false
+  paths:
+    read: ["**"]
+    write: []
 ---
 
 # Git Commit 技能
@@ -131,6 +143,14 @@ agent_created: false
 - 不要提交敏感信息
 - commit message 用中文
 ```
+
+`permissions` 是请求能力，不是授权能力。有效权限始终是：
+
+```text
+Harness 基础权限 ∩ 当前已审核 Skill manifest
+```
+
+字段采用严格白名单：未知字段、绝对路径、`..` 越界路径和错误类型全部拒绝。`paths` 只约束能理解结构化 `path` 参数的工具；`bash` 这类多用途工具仍需要 s04/s23 的沙盒、审批和出口控制，不能靠字符串扫描获得真正隔离。
 
 ### Frontmatter 解析
 
@@ -503,7 +523,12 @@ read_when:                  # 触发条件 (关键词列表)
   - 提交代码
   - commit
 agent_created: false         # 是否由模型创建
-risk_level: P2               # 安全等级
+permissions:                 # Skill 请求的最小能力
+  tools: [read_file]
+  network: false
+  paths:
+    read: ["docs/**"]
+    write: []
 ---
 ```
 
@@ -560,6 +585,8 @@ const SkillTool = {
 | P1 | 包含网络/安装操作 (curl, npm install) | 需用户确认 |
 | P2 | 安全内容 | 直接安装 |
 
+此外，`permission_diff()` 会把新版相对旧版新增的工具、网络、读路径和写路径单独列出。任何权限扩大都进入 P1 人工审批；运行时 `authorize_skill_tool()` 再检查实际工具调用，防止只审安装、不审执行。
+
 ### 自动保存技能
 
 WorkBuddy 的一个设计原则：**完成多步骤任务后，模型必须保存流程为技能**。这让 agent 随着使用越来越强——下次遇到类似任务直接加载技能，不用重新探索。
@@ -576,8 +603,10 @@ WorkBuddy 的一个设计原则：**完成多步骤任务后，模型必须保�
 4. **`load_skill()`** — 按需加载技能完整内容
 5. **`create_skill()`** — 创建新技能（agent_created 标记）
 6. **`audit_skill()`** — 安装前的 P0/P1/P2 安全审计
-7. **`Skill` 工具** — 模型可主动调用的技能加载工具
-8. **agent 循环** — 输入时自动匹配技能，加载后重新组装系统提示
+7. **`parse_skill_permissions()` / `permission_diff()`** — 严格解析权限并显示升级
+8. **`authorize_skill_tool()`** — 执行前校验工具、网络和结构化路径
+9. **`Skill` 工具** — 模型可主动调用的技能加载工具
+10. **agent 循环** — 输入时自动匹配技能，加载后重新组装系统提示
 
 预设了 3 个示例技能（git-commit、code-review、deploy-check）在内存中模拟。运行后试试说"帮我提交代码"——观察技能匹配和加载过程。
 
@@ -587,6 +616,7 @@ WorkBuddy 的一个设计原则：**完成多步骤任务后，模型必须保�
 
 ```bash
 python s16_skills_system/code.py
+python -m pytest -q tests/test_skill_permissions.py
 ```
 
 ---

--- a/s16_skills_system/code.py
+++ b/s16_skills_system/code.py
@@ -8,7 +8,8 @@ Skills are stored in two levels:
   - Project-level: {workspace}/.workbuddy/skills/ (project-specific, shared)
 
 Each skill is a directory with a SKILL.md file.
-SKILL.md has YAML frontmatter: title, summary, read_when (triggers).
+SKILL.md has YAML frontmatter: title, summary, read_when (triggers), and a
+strict permissions manifest for tools, network, and workspace-relative paths.
 
 Loading is on-demand:
   1. Startup: scan frontmatter → build index (no full content loaded)
@@ -35,7 +36,7 @@ Loading is on-demand:
   └───────────────────────────────────────────────────┘
 
 Production harnesses often use: same frontmatter + on-demand model in agent bridge,
-with P0/P1/P2 security audit on install.
+with install audit, permission diff, runtime policy, and sandbox enforcement.
 Teaching version uses: in-memory skills, keyword matching.
 
 Usage:
@@ -48,8 +49,9 @@ Usage:
 # chapter declares what it inherits and what it adds.
 PROGRESSION = {'chapter': 's16_skills_system',
  'builds_on': ['s15_prompt_assembly'],
- 'adds': ['SKILL.md discovery', 'frontmatter parsing', 'on-demand skill loading'],
- 'preserves': ['prompt assembly pipeline']}
+ 'adds': ['SKILL.md discovery', 'frontmatter parsing', 'on-demand skill loading',
+          'declarative skill permissions'],
+ 'preserves': ['prompt assembly pipeline', 'harness permission ceiling']}
 
 # Shared learning entrypoints: --demo is offline; --provider deepseek configures real API env.
 import sys as _wb_sys
@@ -61,7 +63,7 @@ from mini_workbuddy.chapter_demo import maybe_run_chapter_demo as _wb_maybe_run_
 _wb_maybe_run_chapter_demo(__file__, PROGRESSION)
 from mini_workbuddy.chapter_demo import prepare_chapter_provider as _wb_prepare_chapter_provider
 _wb_prepare_chapter_provider()
-import os, sys, time, json
+import fnmatch, os, re, sys, time, json
 from pathlib import Path
 from dataclasses import dataclass, field
 
@@ -96,6 +98,172 @@ except ImportError:
 
 
 # ======================================================================
+# Declarative skill permissions
+# ======================================================================
+
+class SkillPermissionError(ValueError):
+    """Raised when a skill permission manifest is malformed."""
+
+
+@dataclass(frozen=True)
+class SkillPermissions:
+    """Capabilities requested by one skill.
+
+    This manifest can only narrow the harness policy. Declaring a capability
+    never grants authority that the underlying permission layer denied.
+    """
+
+    tools: tuple[str, ...] = ()
+    network: bool = False
+    read_paths: tuple[str, ...] = ()
+    write_paths: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict:
+        return {
+            "tools": list(self.tools),
+            "network": self.network,
+            "paths": {
+                "read": list(self.read_paths),
+                "write": list(self.write_paths),
+            },
+        }
+
+
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9_.:-]+$")
+_NETWORK_COMMAND_PATTERNS = (
+    "curl ", "wget ", "git clone", "npm install", "pip install",
+)
+
+
+def _unique_strings(value, *, field_name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise SkillPermissionError(f"permissions.{field_name} must be a list")
+    result = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise SkillPermissionError(
+                f"permissions.{field_name} entries must be non-empty strings"
+            )
+        item = item.strip()
+        if item not in result:
+            result.append(item)
+    return tuple(result)
+
+
+def _validate_path_pattern(pattern: str, *, field_name: str) -> str:
+    normalized = pattern.replace("\\", "/")
+    if re.match(r"^[A-Za-z]:/", normalized) or normalized.startswith("/"):
+        raise SkillPermissionError(
+            f"permissions.paths.{field_name} must stay relative to the workspace"
+        )
+    parts = [part for part in normalized.split("/") if part not in ("", ".")]
+    if not parts or ".." in parts:
+        raise SkillPermissionError(
+            f"permissions.paths.{field_name} must not escape the workspace"
+        )
+    return "/".join(parts)
+
+
+def parse_skill_permissions(value) -> SkillPermissions:
+    """Parse a strict, fail-closed permissions block from frontmatter."""
+    if value is None:
+        return SkillPermissions()
+    if not isinstance(value, dict):
+        raise SkillPermissionError("permissions must be a mapping")
+
+    unknown = set(value) - {"tools", "network", "paths"}
+    if unknown:
+        raise SkillPermissionError(
+            f"unknown permissions fields: {', '.join(sorted(unknown))}"
+        )
+
+    tools = _unique_strings(value.get("tools", []), field_name="tools")
+    for tool in tools:
+        if not _TOOL_NAME.fullmatch(tool):
+            raise SkillPermissionError(f"invalid tool name in permissions.tools: {tool}")
+
+    network = value.get("network", False)
+    if not isinstance(network, bool):
+        raise SkillPermissionError("permissions.network must be true or false")
+
+    paths = value.get("paths", {})
+    if not isinstance(paths, dict):
+        raise SkillPermissionError("permissions.paths must be a mapping")
+    unknown_paths = set(paths) - {"read", "write"}
+    if unknown_paths:
+        raise SkillPermissionError(
+            f"unknown permissions.paths fields: {', '.join(sorted(unknown_paths))}"
+        )
+
+    read_paths = tuple(
+        _validate_path_pattern(pattern, field_name="read")
+        for pattern in _unique_strings(paths.get("read", []), field_name="paths.read")
+    )
+    write_paths = tuple(
+        _validate_path_pattern(pattern, field_name="write")
+        for pattern in _unique_strings(paths.get("write", []), field_name="paths.write")
+    )
+    return SkillPermissions(tools, network, read_paths, write_paths)
+
+
+def permission_diff(
+    previous: SkillPermissions, requested: SkillPermissions
+) -> dict[str, object]:
+    """Return only permission additions so updates can surface escalation."""
+    return {
+        "added_tools": sorted(set(requested.tools) - set(previous.tools)),
+        "network_enabled": requested.network and not previous.network,
+        "added_read_paths": sorted(
+            set(requested.read_paths) - set(previous.read_paths)
+        ),
+        "added_write_paths": sorted(
+            set(requested.write_paths) - set(previous.write_paths)
+        ),
+    }
+
+
+def has_permission_escalation(diff: dict[str, object]) -> bool:
+    return any(bool(value) for value in diff.values())
+
+
+def _path_is_allowed(path: str, patterns: tuple[str, ...], workdir: Path) -> bool:
+    try:
+        resolved = (workdir / path).resolve()
+        relative = resolved.relative_to(workdir.resolve()).as_posix()
+    except (OSError, ValueError):
+        return False
+    return any(fnmatch.fnmatchcase(relative, pattern) for pattern in patterns)
+
+
+def authorize_skill_tool(
+    skill: "Skill", tool_name: str, tool_input: dict, *, workdir: Path | None = None
+) -> tuple[bool, str]:
+    """Check one skill manifest before the harness executes a tool call."""
+    if tool_name not in skill.permissions.tools:
+        return False, f"skill '{skill.title}' did not declare tool '{tool_name}'"
+
+    command = str(tool_input.get("command", "")).lower()
+    if tool_name == "bash" and any(
+        pattern in command for pattern in _NETWORK_COMMAND_PATTERNS
+    ) and not skill.permissions.network:
+        return False, f"skill '{skill.title}' did not declare network access"
+
+    path = tool_input.get("path")
+    if isinstance(path, str) and tool_name == "read_file":
+        root = workdir or WORKDIR
+        if not _path_is_allowed(path, skill.permissions.read_paths, root):
+            return False, f"skill '{skill.title}' cannot read path '{path}'"
+    if isinstance(path, str) and tool_name == "write_file":
+        root = workdir or WORKDIR
+        if not _path_is_allowed(path, skill.permissions.write_paths, root):
+            return False, f"skill '{skill.title}' cannot write path '{path}'"
+
+    return True, "allowed by skill manifest; harness policy still applies"
+
+
+# ======================================================================
 # SKILL.md parsing
 # ======================================================================
 
@@ -109,6 +277,7 @@ class Skill:
     content: str = ""           # Full content (loaded on demand)
     loaded: bool = False        # Whether full content is in context
     agent_created: bool = False
+    permissions: SkillPermissions = field(default_factory=SkillPermissions)
 
     def index_line(self) -> str:
         """One-line index entry for system prompt (compact)."""
@@ -133,6 +302,8 @@ def parse_frontmatter(text: str) -> tuple[dict, str]:
 
     if yaml:
         fm = yaml.safe_load(parts[1]) or {}
+        if not isinstance(fm, dict):
+            raise SkillPermissionError("frontmatter must be a mapping")
     else:
         # Fallback: simple parsing without yaml
         fm = {}
@@ -162,6 +333,7 @@ def parse_skill_md(filepath: Path) -> Skill | None:
         content=body,
         loaded=False,
         agent_created=fm.get("agent_created", False),
+        permissions=parse_skill_permissions(fm.get("permissions")),
     )
 
 
@@ -183,6 +355,12 @@ read_when:
   - git push
   - 保存修改
 agent_created: false
+permissions:
+  tools: [bash]
+  network: false
+  paths:
+    read: ["**"]
+    write: []
 ---
 
 # Git Commit 技能
@@ -211,6 +389,12 @@ read_when:
   - review
   - 审查代码
 agent_created: false
+permissions:
+  tools: [read_file]
+  network: false
+  paths:
+    read: ["**"]
+    write: []
 ---
 
 # Code Review 技能
@@ -239,6 +423,12 @@ read_when:
   - 上线
   - 发布
 agent_created: false
+permissions:
+  tools: [bash]
+  network: false
+  paths:
+    read: ["**"]
+    write: []
 ---
 
 # Deploy Check 技能
@@ -281,6 +471,7 @@ def build_skill_index() -> list[Skill]:
             content=body,
             loaded=False,
             agent_created=fm.get("agent_created", False),
+            permissions=parse_skill_permissions(fm.get("permissions")),
         )
         skills.append(skill)
     return skills
@@ -329,7 +520,7 @@ def load_skill(title: str) -> str:
 
 
 def create_skill(title: str, summary: str, read_when: list[str],
-                 content: str) -> str:
+                 content: str, permissions: dict | None = None) -> str:
     """Create a new skill.
 
     In real WorkBuddy, this writes to ~/.workbuddy/skills/{title}/SKILL.md
@@ -340,14 +531,20 @@ def create_skill(title: str, summary: str, read_when: list[str],
     if existing:
         return f"技能 '{title}' 已存在。"
 
+    requested_permissions = parse_skill_permissions(permissions)
+
     # Build SKILL.md content
     triggers_yaml = "\n".join(f"  - {t}" for t in read_when)
+    permissions_yaml = json.dumps(
+        requested_permissions.as_dict(), ensure_ascii=False
+    )
     skill_md = f"""---
 title: {title}
 summary: {summary}
 read_when:
 {triggers_yaml}
 agent_created: true
+permissions: {permissions_yaml}
 ---
 
 {content}"""
@@ -361,6 +558,7 @@ agent_created: true
         content=body,
         loaded=False,
         agent_created=True,
+        permissions=requested_permissions,
     )
     skill_index.append(new_skill)
     SEED_SKILLS[title] = skill_md  # Keep in sync
@@ -368,7 +566,10 @@ agent_created: true
     return f"技能 '{title}' 已创建。"
 
 
-def audit_skill(skill_content: str) -> tuple[str, str]:
+def audit_skill(
+    skill_content: str,
+    previous_permissions: SkillPermissions | None = None,
+) -> tuple[str, str]:
     """Security audit a skill before installing.
 
     P0: Dangerous patterns — block installation
@@ -378,6 +579,14 @@ def audit_skill(skill_content: str) -> tuple[str, str]:
     Production harness: more sophisticated AST analysis.
     Teaching version: pattern matching.
     """
+    try:
+        frontmatter, _ = parse_frontmatter(skill_content)
+        requested_permissions = parse_skill_permissions(
+            frontmatter.get("permissions")
+        )
+    except SkillPermissionError as exc:
+        return ("P0", f"禁止安装: 权限声明无效 ({exc})")
+
     p0_patterns = [
         ("rm -rf /", "递归删除根目录"),
         ("sudo ", "提权操作"),
@@ -403,6 +612,18 @@ def audit_skill(skill_content: str) -> tuple[str, str]:
     for pattern, desc in p1_patterns:
         if pattern in skill_content:
             return ("P1", f"需审批: 包含 '{pattern}' ({desc})")
+
+    if previous_permissions is not None:
+        diff = permission_diff(previous_permissions, requested_permissions)
+        if has_permission_escalation(diff):
+            return (
+                "P1",
+                "需审批: Skill 更新扩大权限 "
+                + json.dumps(diff, ensure_ascii=False, sort_keys=True),
+            )
+
+    if requested_permissions.network or requested_permissions.write_paths:
+        return ("P1", "需审批: Skill 请求网络访问或写路径权限")
 
     return ("P2", "安全: 未检测到危险模式")
 
@@ -498,6 +719,30 @@ TOOLS = [
 TOOL_HANDLERS = {"Skill": run_skill, "bash": run_bash, "read_file": run_read}
 
 
+def authorize_loaded_skill_tool(
+    tool_name: str, tool_input: dict, *, workdir: Path | None = None
+) -> tuple[bool, str]:
+    """Apply active Skill overlays without replacing the base harness policy.
+
+    With no active skill, s04-style harness permissions remain authoritative.
+    When skills are active, at least one reviewed manifest must declare the
+    capability. A production dispatcher should also bind each call to its
+    originating skill instead of using this teaching union.
+    """
+    if tool_name == "Skill" or not loaded_skills:
+        return True, "base harness policy applies"
+
+    reasons = []
+    for skill in loaded_skills:
+        allowed, reason = authorize_skill_tool(
+            skill, tool_name, tool_input, workdir=workdir
+        )
+        if allowed:
+            return True, reason
+        reasons.append(reason)
+    return False, "; ".join(reasons)
+
+
 # ======================================================================
 # Agent Loop
 # ======================================================================
@@ -522,8 +767,13 @@ def agent_loop(messages: list):
             if block.type != "tool_use":
                 continue
 
+            tool_input = dict(block.input) if block.input else {}
+            allowed, reason = authorize_loaded_skill_tool(block.name, tool_input)
             handler = TOOL_HANDLERS.get(block.name)
-            output = handler(**block.input) if handler else f"Unknown: {block.name}"
+            if not allowed:
+                output = f"Permission denied: {reason}"
+            else:
+                output = handler(**tool_input) if handler else f"Unknown: {block.name}"
 
             # Special display for Skill tool
             if block.name == "Skill":

--- a/s17_mcp_connectors/README.md
+++ b/s17_mcp_connectors/README.md
@@ -1,6 +1,6 @@
 # s17: MCP Connectors — 外接工具, 标准协议, 信任模型
 
-> *"外接工具, 标准协议, 信任模型"* — MCP 让 agent 的工具池可以无限扩展，但每个外接工具都需要用户手动信任。
+> *"外接工具, 标准协议, 信任模型"* — MCP 让 agent 的工具池可以扩展；Connector 要受信任，具体工具还要被当前 Skill 显式声明。
 >
 > **Harness 层**: 扩展生态 — agent 的外接工具系统。
 
@@ -14,7 +14,11 @@
 flowchart LR
     A["MCP Config"] --> B["Client Handshake"]
     B --> C["Tool Schema Import"]
-    C --> D["Tool Dispatch"]
+    T["Connector Trust"] --> G{"Trust ∩ Skill Grant"}
+    P["Skill Permission Grant"] --> G
+    C --> G
+    G -->|Allow| D["Tool Dispatch"]
+    G -->|Deny| X["Permission Error"]
     D --> E["Remote Tool Result"]
     C -. "state" .-> S["runtime state"]
     S -. "recover" .-> C
@@ -37,6 +41,7 @@ flowchart LR
 - 连接器越多越好是错觉, 工具膨胀会降低选择质量。
 - 未信任连接器直接暴露给模型, 风险很高。
 - MCP 工具不走统一审计, 会出现治理盲区。
+- 信任一个 Connector 不等于允许每个 Skill 调用它的全部工具。
 ## 问题
 
 s16 的 Skills 系统让 agent 可以按需加载单个技能。但技能本质上是 prompt 模板——它们告诉 agent "怎么做"，而不是提供新的"能做什么"。
@@ -47,7 +52,7 @@ s16 的 Skills 系统让 agent 可以按需加载单个技能。但技能本质�
 
 MCP（Model Context Protocol）解决了这个问题。它定义了一个标准协议：任何工具只要实现 `tools/list`（列出你能做什么）和 `tools/call`（执行某个工具），就可以被任何 MCP 客户端发现和使用。工具开发者和 agent 开发者彻底解耦。
 
-但"外接工具"带来了一个安全问题：一个恶意连接器可以执行任意命令、窃取数据。WorkBuddy 的答案是信任模型——每个连接器必须由用户手动 "Trust" 后才会激活。
+但"外接工具"带来了一个安全问题：一个恶意连接器可以执行任意命令、窃取数据。第一道门是信任模型——每个连接器必须由用户手动 "Trust" 后才会激活；第二道门是 Skill 权限——已连接工具只有同时出现在审核后的工具白名单中、且允许网络访问时，才会进入延迟工具池。
 
 ---
 
@@ -60,7 +65,7 @@ MCP（Model Context Protocol）解决了这个问题。它定义了一个标准�
        │              │               │            │
        │              │               │            │
   mcp.json 写入   进程未启动      用户点击 Trust   tools/list 发现
-  配置已保存      工具池不可见     信任持久化       tools/call 可用
+  配置已保存      工具池不可见     信任持久化       再与 Skill Grant 求交集
 
 
            ┌──────────────────────────────────────┐
@@ -83,7 +88,7 @@ MCP（Model Context Protocol）解决了这个问题。它定义了一个标准�
 | configured | 配置写入 `mcp.json` | 不可见 |
 | disconnected | 进程未启动 | 不可见 |
 | trusted | 用户已信任，进程待启动 | 不可见 |
-| connected | 进程启动，`tools/list` 完成 | 可见（延迟加载） |
+| connected | 进程启动，`tools/list` 完成 | 仅已声明工具可见（延迟加载） |
 
 MCP 协议核心方法：
 
@@ -140,6 +145,18 @@ def trust_connector(connector_name: str):
 
 信任状态持久化在 `~/.workbuddy/connector_trust.json`。未信任的连接器不会启动进程，其工具不会出现在工具池中。
 
+信任只决定 Connector 进程能否启动，不决定某个 Skill 能调用哪些工具。教学实现使用独立的 `MCPPermissionGrant`：
+
+```python
+grant = MCPPermissionGrant(
+    tools={"mcp__github__list_issues"},
+    network=True,
+)
+manager = ConnectorManager(MCP_CONFIG, grant)
+```
+
+省略 grant 时默认 `NO_MCP_PERMISSIONS`，即使 Connector 已受信任也不暴露任何工具。更新或撤销 grant 会清空已加载 schema；执行阶段还会重新检查，避免“先加载、后撤权、仍可执行”的 TOCTOU 缺口。
+
 ### 工具发现
 
 连接器被信任并启动后，agent 发送 `tools/list` 请求：
@@ -154,6 +171,8 @@ def discover_tools(connector_name: str) -> list[dict]:
     for tool in response.get("tools", []):
         # 命名空间化: mcp__connectorname__toolname
         namespaced_name = f"mcp__{connector_name}__{tool['name']}"
+        if not active_skill_grant.allows(namespaced_name):
+            continue
         discovered.append({
             "name": namespaced_name,
             "description": tool["description"],
@@ -180,9 +199,9 @@ DEFERRED_TOOLS = [
 
 # 当 agent 决定使用某个延迟工具时:
 # 1. ToolSearch 加载 schema
-schema = tool_search("mcp__github__create_pr")
+schema = tool_search("mcp__github__create_pr")  # 再检查 Skill grant
 # 2. DeferExecuteTool 执行
-result = defer_execute_tool("mcp__github__create_pr", {"title": "...", "body": "..."})
+result = defer_execute_tool("mcp__github__create_pr", {"title": "...", "body": "..."})  # 再检查
 ```
 
 这个设计解决了"工具爆炸"问题——40 个连接器 × 每个 10 个工具 = 400 个工具。如果把 400 个工具的完整 schema 全塞进系统提示，会浪费大量 token。延迟加载让 agent 只在需要时付出代价。
@@ -198,6 +217,8 @@ def build_connector_context() -> str:
     for name, conn in connectors.items():
         if conn.status == "connected":
             for tool in conn.tools:
+                if not active_skill_grant.allows(tool["name"]):
+                    continue
                 lines.append(f"- {tool['name']}: {tool['description']}")
     lines.append("</available_deferred_tools>")
     return "\n".join(lines)
@@ -237,9 +258,10 @@ def build_connector_context() -> str:
 1. 将信任状态写入持久化存储
 2. 启动连接器子进程
 3. 执行 `tools/list` 发现工具
-4. 将工具注册到延迟工具池
+4. 与当前 Skill 的工具/网络 grant 求交集
+5. 只把交集注册到延迟工具池
 
-未信任的连接器显示为 "Not Trusted" 状态，其工具完全不可见。
+未信任的连接器显示为 "Not Trusted" 状态，其工具完全不可见。已信任但未被当前 Skill 声明的工具同样不可见，也不能通过直接构造 `DeferExecuteTool` 调用绕过。
 
 ### 延迟工具加载
 
@@ -276,7 +298,9 @@ WorkBuddy 内置 连接器生态：
 3. **工具发现** — 模拟 `tools/list` 协议方法
 4. **延迟工具加载** — 模拟 `ToolSearch` + `DeferExecuteTool` 模式
 5. **命名空间化** — 工具名格式为 `mcp__connectorname__toolname`
-6. **状态注入** — 将连接器状态注入系统提示
+6. **权限交集** — Connector trust、网络许可和 Skill 工具白名单缺一不可
+7. **双重检查** — `ToolSearch` 与 `DeferExecuteTool` 都 fail closed
+8. **状态注入** — 只将允许的连接器工具注入系统提示
 
 内置模拟连接器：
 - `github` — 模拟 GitHub PR 创建
@@ -289,6 +313,7 @@ WorkBuddy 内置 连接器生态：
 
 ```bash
 python s17_mcp_connectors/code.py
+python -m pytest -q tests/test_skill_permissions.py
 ```
 
 试试这些 prompt：
@@ -298,7 +323,7 @@ python s17_mcp_connectors/code.py
 3. `Create a PR on GitHub to add dark mode`（使用 MCP 工具）
 4. `Send a message on Feishu saying hello`（使用另一个连接器）
 
-观察重点：未信任的连接器工具不可见。信任后工具出现在延迟工具池中。使用时先 ToolSearch 加载 schema，再 DeferExecuteTool 执行。
+观察重点：未信任的连接器工具不可见；信任后还要通过显式 Skill grant。交集中的工具先经 ToolSearch 加载 schema，再经 DeferExecuteTool 二次校验并执行。
 
 ---
 

--- a/s17_mcp_connectors/code.py
+++ b/s17_mcp_connectors/code.py
@@ -15,6 +15,7 @@ Key mechanisms simulated:
   3. tools/list discovery (MCP protocol)
   4. Deferred tool loading (ToolSearch + DeferExecuteTool pattern)
   5. Namespace: mcp__connectorname__toolname
+  6. Connector trust intersected with Skill-scoped MCP permissions
 
 Production harnesses often use:
   - Real MCP server processes (stdio transport) spawned by Sidecar
@@ -39,8 +40,9 @@ Usage:
 # chapter declares what it inherits and what it adds.
 PROGRESSION = {'chapter': 's17_mcp_connectors',
  'builds_on': ['s16_skills_system'],
- 'adds': ['connector config', 'trust workflow', 'MCP tool namespace'],
- 'preserves': ['lazy capability loading']}
+ 'adds': ['connector config', 'trust workflow', 'MCP tool namespace',
+          'skill-scoped MCP permissions'],
+ 'preserves': ['lazy capability loading', 'harness permission ceiling']}
 
 # Shared learning entrypoints: --demo is offline; --provider deepseek configures real API env.
 import sys as _wb_sys
@@ -175,6 +177,49 @@ SIMULATED_TOOLS = {
 
 
 # ============================================================
+# Skill-scoped MCP permission contract
+# ============================================================
+
+@dataclass(frozen=True)
+class MCPPermissionGrant:
+    """Reviewed Skill capabilities intersected with connector trust.
+
+    Trust answers whether a connector process may run. This grant separately
+    answers which of its remote tools one active Skill may discover and call.
+    """
+
+    tools: frozenset[str] = frozenset()
+    network: bool = False
+
+    def __post_init__(self):
+        if not isinstance(self.network, bool):
+            raise ValueError("MCP permission network must be true or false")
+        if isinstance(self.tools, (str, bytes)):
+            raise ValueError("MCP permission tools must be a collection of names")
+        normalized = frozenset(self.tools)
+        if any(
+            not isinstance(tool, str) or not tool.startswith("mcp__")
+            for tool in normalized
+        ):
+            raise ValueError("MCP permission tools must use namespaced mcp__ names")
+        object.__setattr__(self, "tools", normalized)
+
+    def allows(self, tool_name: str) -> bool:
+        return self.network and tool_name in self.tools
+
+
+NO_MCP_PERMISSIONS = MCPPermissionGrant()
+DEMO_MCP_PERMISSIONS = MCPPermissionGrant(
+    tools=frozenset(
+        f"mcp__{connector_name}__{tool['name']}"
+        for connector_name, tools in SIMULATED_TOOLS.items()
+        for tool in tools
+    ),
+    network=True,
+)
+
+
+# ============================================================
 # Connector Lifecycle Management
 # ============================================================
 
@@ -248,14 +293,36 @@ class MCPConnector:
 class ConnectorManager:
     """Manages all MCP connectors — parse config, trust, connect, discover."""
 
-    def __init__(self, config: dict):
+    def __init__(
+        self,
+        config: dict,
+        permission_grant: MCPPermissionGrant | None = None,
+    ):
         self.connectors: dict[str, MCPConnector] = {}
         self._deferred_schemas: dict[str, dict] = {}  # tool_name -> full schema
+        self.permission_grant = permission_grant or NO_MCP_PERMISSIONS
 
         # Parse config
         for name, cfg in config.get("mcpServers", {}).items():
             self.connectors[name] = MCPConnector(name=name, config=cfg)
         print(f"\033[90m[MCP] Loaded {len(self.connectors)} connector configs from mcp.json\033[0m")
+
+    def set_permission_grant(self, grant: MCPPermissionGrant) -> None:
+        """Replace reviewed permissions and invalidate previously loaded schemas."""
+        self.permission_grant = grant
+        self._deferred_schemas.clear()
+
+    def _permission_denial(self, tool_name: str) -> dict:
+        reason = (
+            "network access is not declared"
+            if not self.permission_grant.network
+            else "tool is not declared by the active skill"
+        )
+        return {
+            "error": f"Permission denied for '{tool_name}': {reason}.",
+            "code": "permission_denied",
+            "tool": tool_name,
+        }
 
     def list_connectors(self) -> str:
         """Display all connectors and their status."""
@@ -297,10 +364,11 @@ class ConnectorManager:
         for conn in self.connectors.values():
             if conn.status == "connected":
                 for tool in conn.tools:
-                    tools.append({
-                        "name": tool["name"],
-                        "description": tool["description"],
-                    })
+                    if self.permission_grant.allows(tool["name"]):
+                        tools.append({
+                            "name": tool["name"],
+                            "description": tool["description"],
+                        })
         return tools
 
     def tool_search(self, tool_name: str) -> dict | None:
@@ -309,6 +377,9 @@ class ConnectorManager:
         Production harness: agent calls ToolSearch with tool_names list,
         system returns full input_schema for each.
         """
+        if not self.permission_grant.allows(tool_name):
+            return self._permission_denial(tool_name)
+
         for conn in self.connectors.values():
             if conn.status != "connected":
                 continue
@@ -328,6 +399,12 @@ class ConnectorManager:
 
         Production harness: agent calls DeferExecuteTool with validated params.
         """
+        # Re-check permissions at execution time so revocation is fail-closed.
+        if not self.permission_grant.allows(tool_name):
+            return json.dumps(
+                self._permission_denial(tool_name), ensure_ascii=False
+            )
+
         # Verify schema was loaded
         if tool_name not in self._deferred_schemas:
             return f"Error: Tool '{tool_name}' schema not loaded. Call ToolSearch first."
@@ -496,7 +573,9 @@ if __name__ == "__main__":
     print("  q         — Quit")
     print()
 
-    manager = ConnectorManager(MCP_CONFIG)
+    # The interactive tour uses an explicit reviewed grant. Library callers
+    # that omit it receive NO_MCP_PERMISSIONS and therefore fail closed.
+    manager = ConnectorManager(MCP_CONFIG, DEMO_MCP_PERMISSIONS)
     agent = MCPAgent(manager)
 
     print(manager.list_connectors())

--- a/tests/test_skill_permissions.py
+++ b/tests/test_skill_permissions.py
@@ -1,0 +1,274 @@
+"""Offline contracts for declarative Skill and MCP permissions."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_chapter(module_name: str, chapter: str):
+    stub_dir = ROOT / "tests" / "stubs"
+    sys.path.insert(0, str(stub_dir))
+    saved_anthropic = sys.modules.pop("anthropic", None)
+    old_model = os.environ.get("MODEL_ID")
+    os.environ["MODEL_ID"] = "offline-test-model"
+    try:
+        spec = importlib.util.spec_from_file_location(
+            module_name, ROOT / chapter / "code.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(stub_dir))
+        sys.modules.pop("anthropic", None)
+        if saved_anthropic is not None:
+            sys.modules["anthropic"] = saved_anthropic
+        if old_model is None:
+            os.environ.pop("MODEL_ID", None)
+        else:
+            os.environ["MODEL_ID"] = old_model
+
+
+@pytest.fixture(scope="module")
+def s16():
+    module_name = "s16_skill_permissions_test_module"
+    module = _load_chapter(module_name, "s16_skills_system")
+    try:
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+@pytest.fixture(scope="module")
+def s17():
+    module_name = "s17_skill_permissions_test_module"
+    module = _load_chapter(module_name, "s17_mcp_connectors")
+    try:
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def _skill_markdown(permissions: str) -> str:
+    return f"""---
+title: docs-reader
+summary: Read project documentation
+read_when: [docs]
+agent_created: true
+permissions:
+{permissions}
+---
+
+# Docs reader
+Read the requested documentation before answering.
+"""
+
+
+def test_s16_parses_strict_permission_manifest(s16, tmp_path: Path) -> None:
+    skill_path = tmp_path / "SKILL.md"
+    skill_path.write_text(
+        _skill_markdown(
+            "  tools: [read_file]\n"
+            "  network: false\n"
+            "  paths:\n"
+            "    read: [\"./docs/**\"]\n"
+            "    write: []"
+        ),
+        encoding="utf-8",
+    )
+
+    skill = s16.parse_skill_md(skill_path)
+
+    assert skill is not None
+    assert skill.permissions.tools == ("read_file",)
+    assert skill.permissions.network is False
+    assert skill.permissions.read_paths == ("docs/**",)
+    assert skill.permissions.write_paths == ()
+
+
+@pytest.mark.parametrize(
+    "permissions, message",
+    [
+        ("  tools: [read_file]\n  shell: true", "unknown permissions fields"),
+        ("  tools: read_file", "permissions.tools must be a list"),
+        (
+            "  paths:\n    read: [\"../private/**\"]",
+            "must not escape the workspace",
+        ),
+        (
+            "  paths:\n    write: [\"C:/Users/private/**\"]",
+            "must stay relative to the workspace",
+        ),
+    ],
+)
+def test_s16_rejects_unknown_or_escaping_permissions(
+    s16, permissions: str, message: str
+) -> None:
+    frontmatter, _ = s16.parse_frontmatter(_skill_markdown(permissions))
+
+    with pytest.raises(s16.SkillPermissionError, match=message):
+        s16.parse_skill_permissions(frontmatter["permissions"])
+
+
+def test_s16_runtime_gate_checks_tool_network_and_path(s16, tmp_path: Path) -> None:
+    skill = s16.Skill(
+        title="docs-reader",
+        summary="Read docs",
+        read_when=["docs"],
+        path="(test)",
+        permissions=s16.SkillPermissions(
+            tools=("read_file", "bash"),
+            network=False,
+            read_paths=("docs/**",),
+        ),
+    )
+
+    allowed, _ = s16.authorize_skill_tool(
+        skill, "read_file", {"path": "docs/guide.md"}, workdir=tmp_path
+    )
+    escaped, escaped_reason = s16.authorize_skill_tool(
+        skill, "read_file", {"path": "../secret.txt"}, workdir=tmp_path
+    )
+    undeclared, undeclared_reason = s16.authorize_skill_tool(
+        skill, "write_file", {"path": "docs/output.md"}, workdir=tmp_path
+    )
+    networked, network_reason = s16.authorize_skill_tool(
+        skill, "bash", {"command": "git clone https://example.invalid/repo"}
+    )
+
+    assert allowed is True
+    assert escaped is False and "cannot read path" in escaped_reason
+    assert undeclared is False and "did not declare tool" in undeclared_reason
+    assert networked is False and "network access" in network_reason
+
+
+def test_s16_loaded_skill_overlay_restricts_base_tools(s16, tmp_path: Path) -> None:
+    original = list(s16.loaded_skills)
+    s16.loaded_skills[:] = [
+        s16.Skill(
+            title="docs-reader",
+            summary="Read docs",
+            read_when=["docs"],
+            path="(test)",
+            permissions=s16.SkillPermissions(
+                tools=("read_file",), read_paths=("docs/**",)
+            ),
+        )
+    ]
+    try:
+        read_allowed, _ = s16.authorize_loaded_skill_tool(
+            "read_file", {"path": "docs/guide.md"}, workdir=tmp_path
+        )
+        bash_allowed, reason = s16.authorize_loaded_skill_tool(
+            "bash", {"command": "git status"}, workdir=tmp_path
+        )
+    finally:
+        s16.loaded_skills[:] = original
+
+    assert read_allowed is True
+    assert bash_allowed is False
+    assert "did not declare tool" in reason
+
+
+def test_s16_audit_surfaces_permission_escalation(s16) -> None:
+    previous = s16.SkillPermissions(
+        tools=("read_file",), read_paths=("docs/**",)
+    )
+    updated = _skill_markdown(
+        "  tools: [read_file, bash]\n"
+        "  network: false\n"
+        "  paths:\n"
+        "    read: [\"docs/**\"]\n"
+        "    write: []"
+    )
+
+    level, report = s16.audit_skill(updated, previous)
+
+    assert level == "P1"
+    assert "扩大权限" in report
+    assert "bash" in report
+
+
+def test_s16_safe_read_only_manifest_remains_p2(s16) -> None:
+    level, report = s16.audit_skill(
+        _skill_markdown(
+            "  tools: [read_file]\n"
+            "  network: false\n"
+            "  paths:\n"
+            "    read: [\"docs/**\"]\n"
+            "    write: []"
+        )
+    )
+
+    assert level == "P2"
+    assert "安全" in report
+
+
+def test_s17_trust_without_skill_grant_exposes_no_tools(s17) -> None:
+    manager = s17.ConnectorManager(s17.MCP_CONFIG)
+    assert manager.trust_connector("github") is True
+
+    assert manager.get_deferred_tools_list() == []
+    denial = manager.tool_search("mcp__github__list_issues")
+    assert denial["code"] == "permission_denied"
+    assert "permission_denied" in manager.defer_execute_tool(
+        "mcp__github__list_issues", {"repo": "owner/repo"}
+    )
+
+
+def test_s17_grant_filters_discovery_and_rechecks_execution(s17) -> None:
+    allowed_tool = "mcp__github__list_issues"
+    manager = s17.ConnectorManager(
+        s17.MCP_CONFIG,
+        s17.MCPPermissionGrant(tools={allowed_tool}, network=True),
+    )
+    manager.trust_all()
+
+    assert [tool["name"] for tool in manager.get_deferred_tools_list()] == [
+        allowed_tool
+    ]
+    schema = manager.tool_search(allowed_tool)
+    assert schema["name"] == allowed_tool
+
+    result = json.loads(
+        manager.defer_execute_tool(allowed_tool, {"repo": "owner/repo"})
+    )
+    assert result["status"] == "ok"
+
+    manager.set_permission_grant(s17.NO_MCP_PERMISSIONS)
+    revoked = json.loads(
+        manager.defer_execute_tool(allowed_tool, {"repo": "owner/repo"})
+    )
+    assert revoked["code"] == "permission_denied"
+
+
+def test_s17_tool_allowlist_still_requires_network_permission(s17) -> None:
+    tool_name = "mcp__github__list_issues"
+    manager = s17.ConnectorManager(
+        s17.MCP_CONFIG,
+        s17.MCPPermissionGrant(tools={tool_name}, network=False),
+    )
+    manager.trust_connector("github")
+
+    assert manager.get_deferred_tools_list() == []
+    assert manager.tool_search(tool_name)["code"] == "permission_denied"
+
+
+def test_s17_rejects_non_namespaced_or_malformed_grants(s17) -> None:
+    with pytest.raises(ValueError, match="collection"):
+        s17.MCPPermissionGrant(tools="mcp__github__list_issues", network=True)
+    with pytest.raises(ValueError, match="namespaced"):
+        s17.MCPPermissionGrant(tools={"list_issues"}, network=True)
+    with pytest.raises(ValueError, match="true or false"):
+        s17.MCPPermissionGrant(tools=set(), network="yes")


### PR DESCRIPTION
## 变更描述

为 s16/s17 增加可执行的声明式 Skill 权限契约，使 Skill 生成、Connector 信任与运行时工具调用之间形成 fail-closed 边界。

- s16 严格解析 tools、network、read/write paths；未知字段、绝对路径和越界路径直接拒绝
- Skill 更新生成权限升级 diff，网络/写权限和能力扩大进入 P1 审批
- 活动 Skill 的工具调用在 dispatch 前校验，且 manifest 只能收窄、不能突破 Harness 基础权限
- s17 将 Connector trust 与 Skill grant 求交集，并在 ToolSearch / DeferExecuteTool 两阶段重复检查
- grant 更新或撤销时清空已加载 schema，防止撤权后继续执行
- 保持 24 章主线不变

## 变更类型

- [ ] 新增章节
- [ ] 修复内容错误
- [x] 改进代码示例
- [ ] 改进 SVG 图表
- [ ] 翻译（EN/JA/KO）
- [x] 其他：Skill / MCP 权限安全契约

## 涉及章节

- s16 Skills System
- s17 MCP Connectors
- docs/skill-evolution-and-evaluation.md
- tests/test_skill_permissions.py

## 核心设计

```text
effective capability = Harness base policy ∩ reviewed Skill manifest
MCP capability       = Connector trust ∩ network grant ∩ tool allowlist
```

路径权限仅约束带结构化 path 参数的工具；bash 等多用途工具仍需 s04/s23 的审批、沙盒与出口控制，文档中已明确教学实现边界。

## 测试

- `python -m pytest -q tests/test_skill_permissions.py tests/test_self_evolving_skills.py tests/test_reflection_memory.py tests/test_chapter_imports.py` — 33 passed
- `python -m py_compile s16_skills_system/code.py s17_mcp_connectors/code.py tests/test_skill_permissions.py`
- WSL：s16/s17 `--demo` 与语法检查通过
- 结构检查：24 chapters、29 READMEs with Mermaid、27 images
- `git diff --check`

## 本地环境说明

Windows 完整 `python3 -m pytest -q` / `python3 scripts/verify.py` 会在进入项目检查前受现有 Linux `.venv/lib64` 链接（`WinError 1920`）以及仓库既有 Windows shell/GBK 行为影响；本 PR 的目标测试、章节导入与隔离 WSL 检查均通过。

## 检查清单

- [x] 代码可以通过离线 `--demo` 独立运行
- [x] README 中的“上一课/下一课”链接正确
- [x] 没有引入新的外部依赖
- [ ] SVG 图表 viewBox 以 `0 0 800` 开头（不适用，未修改 SVG）
- [x] 没有 hardcoded API key 或敏感信息
- [ ] 已运行完整 `python3 -m pytest -q`（受上述既有 Windows 环境问题阻塞）
- [ ] 已运行完整 `python3 scripts/verify.py`（受上述既有 Windows 环境问题阻塞）
- [x] 没有加入闭源代码、私有 prompt、未脱敏路径或产品内部细节