### PR TITLE
feat(s15): add context budget planner

### DIFF
--- a/s15_prompt_assembly/README.md
+++ b/s15_prompt_assembly/README.md
@@ -14,8 +14,10 @@
 flowchart LR
     A["Base Rules"] --> B["Memory Blocks"]
     B --> C["Skills/Tools"]
-    C --> D["Prompt Builder"]
-    D --> E["System Prompt"]
+    C --> D["Budget Planner"]
+    D --> E["Required First"]
+    E --> F["Value Selection"]
+    F --> G["System Prompt + Decisions"]
     C -. "state" .-> S["runtime state"]
     S -. "recover" .-> C
 ```
@@ -51,18 +53,18 @@ WorkBuddy 的系统提示可能有 100KB+。它包含：基础指令、身份文
 
 系统提示不是一个字符串，而是一组**片段（segments）**的有序拼接：
 
-| # | 片段 | 来源 | 条件 |
-|---|------|------|------|
-| 1 | 基础指令 | 硬编码 | 始终包含 |
-| 2 | 身份注入 | persona/core.md / persona/identity.md / persona/user.md | 文件存在时 |
-| 3 | 云端记忆 | `<memory>` 块 (s12) | Profile 非空时 |
-| 4 | 项目上下文 | 文件结构、工作目录 | 始终包含 |
-| 5 | 工具描述 | 从注册工具动态生成 | 有工具时 |
-| 6 | 专家指令 | 激活的专家包 | 专家激活时 |
-| 7 | 技能指令 | 已加载技能的 SKILL.md | 技能加载时 |
-| 8 | 连接器状态 | 可用 MCP 连接器 | 有连接器时 |
-| 9 | 区域约定 | 股市颜色、货币符号 | 按区域 |
-| 10 | 工作模式 | craft / plan / ask | 按模式 |
+| # | 片段 | 来源 | 条件 | 预算策略 |
+|---|------|------|------|----------|
+| 1 | 基础指令 | Harness 基础规则 | 始终包含 | required，不允许删除 |
+| 2 | 身份注入 | 用户 persona | 文件存在时 | 可选，高价值 |
+| 3 | 云端记忆 | `<memory>` 块 (s12) | Profile 非空时 | 可选，中等价值，整块取舍 |
+| 4 | 项目上下文 | 工作区文件结构 | 始终构建 | 可选，高价值 |
+| 5 | 工具描述 | Harness 工具注册表 | 有工具时 | required，防止模型臆造工具 |
+| 6 | 专家指令 | 当前激活专家 | 专家激活时 | 可选，高价值 |
+| 7 | 技能指令 | 已加载 SKILL.md | 技能加载时 | 可选，高价值 |
+| 8 | 连接器状态 | 运行时连接器 | 有连接器时 | 可选，较低价值 |
+| 9 | 区域约定 | 当前区域配置 | 按区域 | 可选，低价值 |
+| 10 | 工作模式 | Harness 当前模式 | 始终包含 | required，不允许删除 |
 
 ```
 运行时组装:
@@ -94,6 +96,31 @@ WorkBuddy 的系统提示可能有 100KB+。它包含：基础指令、身份文
 
 ## 工作原理
 
+### 两种顺序不能混为一谈
+
+`priority` 决定最终 Prompt 中片段的展示顺序，`budget_priority` 决定预算不足时谁先获得空间。两者刻意分开：工作模式可以放在 Prompt 最后，但仍然是不可删除的 required 片段；项目上下文可以排在 Memory 后面，却比区域格式更值得保留。
+
+规划器分两阶段执行：
+
+```text
+构建片段并记录 provenance
+  → 先预留 required 片段
+  → required 已超预算则 fail-closed
+  → 可选片段按 budget_priority 从高到低尝试放入
+  → 已选片段按 priority 排序并拼接
+  → 返回 Prompt + included/dropped/inactive 决策
+```
+
+本章使用字符数作为确定性的离线预算单位。它不是声称所有模型都采用同一种 tokenizer；生产适配器可以把长度函数替换为目标模型的 tokenizer，但 required、价值选择、provenance 和决策报告契约不变。
+
+教学 CLI 默认预算是 12,000 字符，也可以通过环境变量收紧后观察决策：
+
+```bash
+PROMPT_BUDGET_CHARS=2000 python s15_prompt_assembly/code.py
+```
+
+如果 required 片段本身已经超过预算，组装会抛出 `PromptBudgetError`，而不是删除安全规则后继续调用模型。
+
 ### 片段定义
 
 每个片段是一个函数，返回字符串（或 None 表示不包含）：
@@ -101,10 +128,16 @@ WorkBuddy 的系统提示可能有 100KB+。它包含：基础指令、身份文
 ```python
 class PromptSegment:
     """系统提示的一个片段。"""
-    def __init__(self, name: str, builder, condition=None):
+    def __init__(self, name: str, builder, condition=None,
+                 priority=50, required=False,
+                 budget_priority=50, provenance="runtime"):
         self.name = name        # 片段名 (用于调试)
         self.builder = builder  # 构建函数 -> str | None
         self.condition = condition or (lambda: True)
+        self.priority = priority              # Prompt 展示顺序
+        self.required = required              # 预算不能删除
+        self.budget_priority = budget_priority # 预算保留价值
+        self.provenance = provenance          # 来源标签
 
     def build(self) -> str | None:
         if not self.condition():
@@ -174,32 +207,20 @@ def build_skill_instructions() -> str | None:
     return "\n\n".join(parts)
 ```
 
-### 拼接
+### 预算规划与拼接
 
 ```python
-def assemble_system_prompt() -> str:
-    """运行时组装系统提示。"""
-    segments = [
-        PromptSegment("base", build_base_instructions),
-        PromptSegment("identity", build_identity),
-        PromptSegment("memory", build_cloud_memory),
-        PromptSegment("project", build_project_context),
-        PromptSegment("tools", build_tool_descriptions),
-        PromptSegment("expert", build_expert_instructions,
-                      condition=lambda: active_expert is not None),
-        PromptSegment("skills", build_skill_instructions,
-                      condition=lambda: len(loaded_skills) > 0),
-        PromptSegment("mode", build_work_mode),
-    ]
+plan = plan_prompt(segments, budget_chars=12_000)
+system_prompt = plan.prompt
 
-    parts = []
-    for seg in segments:
-        content = seg.build()
-        if content:
-            parts.append(content)
-
-    return "\n\n---\n\n".join(parts)
+print(plan.included_names)
+print(plan.dropped_names)
+for decision in plan.decisions:
+    print(decision.name, decision.status,
+          decision.provenance, decision.reason)
 ```
+
+规划器把片段当成原子的信任与来源边界。预算不足时会完整舍弃一个可选 Memory 或 Skill，而不是把它从中间切断；如果某类内容支持安全压缩，应由它自己的 builder 先生成紧凑投影，再交给规划器选择。
 
 ### 重新组装的时机
 
@@ -311,11 +332,12 @@ eventBus.on('identity:changed', () => reassemble());
 
 `code.py` 演示了系统提示的分段组装：
 
-1. **`PromptSegment` 类** — 每个片段有名字、构建函数、条件函数
+1. **`PromptSegment` 类** — 每个片段有名字、构建条件、展示顺序、预算价值、required 标志和 provenance
 2. **10 个片段构建器** — 模拟 WorkBuddy 的全部片段类型
-3. **`assemble_system_prompt()`** — 遍历片段，条件检查，拼接
-4. **重新组装触发** — 演示加载技能、切换专家、切换模式时重新组装
-5. **agent 循环** — 使用组装好的系统提示，支持运行时重新组装
+3. **`plan_prompt()`** — 先保 required，再按价值选择可选片段，并计算分隔符成本
+4. **`PromptPlan` / `SegmentDecision`** — 输出 Prompt 以及可解释的纳入、舍弃与 inactive 决策
+5. **重新组装触发** — 演示加载技能、切换专家、切换模式时重新规划
+6. **agent 循环** — 使用预算内的系统提示，支持运行时重新组装
 
 运行后可以输入 `prompt` 查看当前系统提示的结构，输入 `skill` 模拟加载技能（触发重新组装），输入 `expert` 模拟切换专家。
 
@@ -332,8 +354,8 @@ python s15_prompt_assembly/code.py
 ## 练习
 
 1. 加一个 `build_codebuddy_md()` 片段——读取工作目录下的 `CODEBUDDY.md` 文件，如果存在就注入项目级指令。思考：这个片段和身份注入有什么区别？
-2. 实现片段优先级——某些片段（如基础指令）必须在最前面，某些（如工作模式）必须在最后面。给 `PromptSegment` 加一个 `priority` 字段。
-3. 系统提示可能很大。实现一个 token 预算机制——如果总长度超过预算，优先截断低优先级片段。思考：哪些片段绝对不能截断？
+2. 为目标模型接入 tokenizer，把字符预算替换为 token 预算，并证明预算决策顺序不随长度实现改变。
+3. 为某个可选片段实现安全的紧凑 builder；比较“先压缩再选择”与“直接舍弃”的上下文质量和来源完整性。
 
 ---
 

--- a/s15_prompt_assembly/code.py
+++ b/s15_prompt_assembly/code.py
@@ -84,10 +84,24 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 from mini_workbuddy.paths import tutorial_workbuddy_home
 
+DEFAULT_PROMPT_BUDGET_CHARS = 12_000
+
 load_dotenv(override=True)
 if os.getenv("ANTHROPIC_BASE_URL"): os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
 
+
+def _prompt_budget_from_env() -> int:
+    raw = os.environ.get("PROMPT_BUDGET_CHARS", str(DEFAULT_PROMPT_BUDGET_CHARS))
+    try:
+        budget = int(raw)
+    except ValueError as exc:
+        raise SystemExit("PROMPT_BUDGET_CHARS must be a non-negative integer") from exc
+    if budget < 0:
+        raise SystemExit("PROMPT_BUDGET_CHARS must be a non-negative integer")
+    return budget
+
 WORKDIR = Path.cwd()
+PROMPT_BUDGET_CHARS = _prompt_budget_from_env()
 client = Anthropic(base_url=os.getenv("ANTHROPIC_BASE_URL"))
 MODEL = os.environ.get("MODEL_ID")
 if not MODEL:
@@ -110,6 +124,9 @@ class PromptSegment:
     - builder: function that returns str | None
     - condition: function that returns bool (default: always True)
     - priority: lower = earlier in the prompt (default: 50)
+    - required: a budget may never remove this segment
+    - budget_priority: higher-value optional segments win scarce budget
+    - provenance: source label retained in the assembly decision report
 
     If builder returns None, or condition returns False,
     the segment is not included.
@@ -118,11 +135,179 @@ class PromptSegment:
     builder: Callable[[], str | None]
     condition: Callable[[], bool] = field(default=lambda: True)
     priority: int = 50
+    required: bool = False
+    budget_priority: int = 50
+    provenance: str = "runtime"
 
     def build(self) -> str | None:
         if not self.condition():
             return None
         return self.builder()
+
+
+PROMPT_SEPARATOR = "\n\n---\n\n"
+
+
+class PromptBudgetError(ValueError):
+    """Raised when required prompt segments cannot fit the configured budget."""
+
+
+@dataclass(frozen=True)
+class SegmentDecision:
+    """One explainable include/drop decision made by the budget planner."""
+
+    name: str
+    priority: int
+    required: bool
+    budget_priority: int
+    provenance: str
+    status: str
+    original_chars: int
+    rendered_chars: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class PromptPlan:
+    """Rendered prompt plus the decisions that produced it."""
+
+    prompt: str
+    budget_chars: int | None
+    used_chars: int
+    decisions: tuple[SegmentDecision, ...]
+
+    @property
+    def included_names(self) -> tuple[str, ...]:
+        return tuple(
+            decision.name for decision in self.decisions
+            if decision.status == "included"
+        )
+
+    @property
+    def dropped_names(self) -> tuple[str, ...]:
+        return tuple(
+            decision.name for decision in self.decisions
+            if decision.status == "dropped"
+        )
+
+
+def _rendered_length(contents: list[str]) -> int:
+    if not contents:
+        return 0
+    return sum(len(content) for content in contents) + (
+        len(contents) - 1
+    ) * len(PROMPT_SEPARATOR)
+
+
+def plan_prompt(
+    segments: list[PromptSegment],
+    *,
+    budget_chars: int | None = DEFAULT_PROMPT_BUDGET_CHARS,
+) -> PromptPlan:
+    """Build and select prompt segments under an explicit character budget.
+
+    Required segments are admitted first. Optional segments are considered by
+    descending ``budget_priority`` with stable presentation priority/name tie
+    breaks. Selected content is finally rendered by presentation ``priority``.
+
+    A segment is an atomic trust/provenance block: the planner drops an
+    optional block in full instead of silently slicing memory or instructions.
+    Builders may create their own compact projection before this boundary.
+    """
+    if budget_chars is not None and budget_chars < 0:
+        raise ValueError("budget_chars must be non-negative or None")
+    names = [segment.name for segment in segments]
+    duplicate_names = sorted({name for name in names if names.count(name) > 1})
+    if duplicate_names:
+        raise ValueError(
+            "duplicate prompt segment names: " + ", ".join(duplicate_names)
+        )
+
+    built: list[tuple[PromptSegment, str]] = []
+    for segment in segments:
+        content = segment.build()
+        if content:
+            built.append((segment, content))
+
+    required = [(segment, content) for segment, content in built if segment.required]
+    optional = [(segment, content) for segment, content in built if not segment.required]
+    selected: dict[str, tuple[PromptSegment, str]] = {
+        segment.name: (segment, content) for segment, content in required
+    }
+
+    required_contents = [
+        content for _, content in sorted(
+            required, key=lambda item: (item[0].priority, item[0].name)
+        )
+    ]
+    required_chars = _rendered_length(required_contents)
+    if budget_chars is not None and required_chars > budget_chars:
+        required_names = ", ".join(segment.name for segment, _ in required)
+        raise PromptBudgetError(
+            f"required prompt segments need {required_chars} chars, "
+            f"but budget is {budget_chars}: {required_names}"
+        )
+
+    rejected: dict[str, str] = {}
+    for segment, content in sorted(
+        optional,
+        key=lambda item: (-item[0].budget_priority, item[0].priority, item[0].name),
+    ):
+        candidate = list(selected.values()) + [(segment, content)]
+        ordered_contents = [
+            value for _, value in sorted(
+                candidate, key=lambda item: (item[0].priority, item[0].name)
+            )
+        ]
+        candidate_chars = _rendered_length(ordered_contents)
+        if budget_chars is None or candidate_chars <= budget_chars:
+            selected[segment.name] = (segment, content)
+        else:
+            rejected[segment.name] = (
+                f"needs {candidate_chars} chars after higher-value segments; "
+                f"budget is {budget_chars}"
+            )
+
+    ordered_selected = sorted(
+        selected.values(), key=lambda item: (item[0].priority, item[0].name)
+    )
+    prompt = PROMPT_SEPARATOR.join(content for _, content in ordered_selected)
+
+    decisions: list[SegmentDecision] = []
+    built_by_identity = {id(segment): content for segment, content in built}
+    for segment in sorted(segments, key=lambda item: (item.priority, item.name)):
+        built_content = built_by_identity.get(id(segment))
+        if built_content is None:
+            decisions.append(SegmentDecision(
+                name=segment.name, priority=segment.priority,
+                required=segment.required, budget_priority=segment.budget_priority,
+                provenance=segment.provenance, status="inactive",
+                original_chars=0, rendered_chars=0,
+                reason="condition false or builder returned empty content",
+            ))
+        elif segment.name in selected:
+            decisions.append(SegmentDecision(
+                name=segment.name, priority=segment.priority,
+                required=segment.required, budget_priority=segment.budget_priority,
+                provenance=segment.provenance, status="included",
+                original_chars=len(built_content), rendered_chars=len(built_content),
+                reason="required segment" if segment.required else "fits budget by value order",
+            ))
+        else:
+            decisions.append(SegmentDecision(
+                name=segment.name, priority=segment.priority,
+                required=segment.required, budget_priority=segment.budget_priority,
+                provenance=segment.provenance, status="dropped",
+                original_chars=len(built_content), rendered_chars=0,
+                reason=rejected[segment.name],
+            ))
+
+    return PromptPlan(
+        prompt=prompt,
+        budget_chars=budget_chars,
+        used_chars=len(prompt),
+        decisions=tuple(decisions),
+    )
 
 
 # ======================================================================
@@ -284,52 +469,85 @@ def build_work_mode() -> str:
 # ======================================================================
 
 SEGMENTS: list[PromptSegment] = [
-    PromptSegment("base", build_base_instructions, priority=10),
-    PromptSegment("identity", build_identity, priority=20),
-    PromptSegment("memory", build_cloud_memory, priority=25),
-    PromptSegment("project", build_project_context, priority=30),
-    PromptSegment("tools", build_tool_descriptions, priority=40),
+    PromptSegment(
+        "base", build_base_instructions, priority=10, required=True,
+        provenance="harness:base-rules",
+    ),
+    PromptSegment(
+        "identity", build_identity, priority=20, budget_priority=90,
+        provenance="user:persona",
+    ),
+    PromptSegment(
+        "memory", build_cloud_memory, priority=25, budget_priority=60,
+        provenance="remote:profile-recall",
+    ),
+    PromptSegment(
+        "project", build_project_context, priority=30, budget_priority=80,
+        provenance="workspace:project-context",
+    ),
+    PromptSegment(
+        "tools", build_tool_descriptions, priority=40, required=True,
+        provenance="harness:tool-registry",
+    ),
     PromptSegment("expert", build_expert_instructions,
-                  condition=lambda: active_expert is not None, priority=50),
+                  condition=lambda: active_expert is not None, priority=50,
+                  budget_priority=85, provenance="runtime:active-expert"),
     PromptSegment("skills", build_skill_instructions,
-                  condition=lambda: len(loaded_skills) > 0, priority=55),
+                  condition=lambda: len(loaded_skills) > 0, priority=55,
+                  budget_priority=75, provenance="runtime:loaded-skills"),
     PromptSegment("connectors", build_connector_status,
-                  condition=lambda: len(connectors) > 0, priority=60),
-    PromptSegment("region", build_regional_conventions, priority=70),
-    PromptSegment("mode", build_work_mode, priority=80),
+                  condition=lambda: len(connectors) > 0, priority=60,
+                  budget_priority=40, provenance="runtime:connectors"),
+    PromptSegment(
+        "region", build_regional_conventions, priority=70,
+        budget_priority=20, provenance="runtime:region",
+    ),
+    PromptSegment(
+        "mode", build_work_mode, priority=80, required=True,
+        provenance="harness:work-mode",
+    ),
 ]
 
 
-def assemble_system_prompt(verbose: bool = False) -> str:
+LAST_PROMPT_PLAN: PromptPlan | None = None
+
+
+def assemble_system_prompt(
+    verbose: bool = False,
+    *,
+    budget_chars: int | None = None,
+) -> str:
     """Assemble system prompt from segments.
 
-    1. Sort segments by priority
-    2. Build each segment (check condition)
-    3. Filter out None results
-    4. Join with separator
+    1. Build each segment and keep its provenance
+    2. Reserve required segments
+    3. Select optional segments by budget value
+    4. Render selected segments in presentation order
     """
-    sorted_segments = sorted(SEGMENTS, key=lambda s: s.priority)
-
-    parts = []
-    segment_info = []
-    for seg in sorted_segments:
-        content = seg.build()
-        included = content is not None
-        segment_info.append((seg.name, seg.priority, included,
-                            len(content) if content else 0))
-        if content:
-            parts.append(content)
+    global LAST_PROMPT_PLAN
+    if budget_chars is None:
+        budget_chars = PROMPT_BUDGET_CHARS
+    LAST_PROMPT_PLAN = plan_prompt(SEGMENTS, budget_chars=budget_chars)
 
     if verbose:
-        print(f"\n\033[90m{'片段':<15} {'优先级':>6} {'包含':>6} {'长度':>8}\033[0m")
-        print(f"\033[90m{'─'*15} {'─'*6} {'─'*6} {'─'*8}\033[0m")
-        for name, pri, inc, length in segment_info:
-            mark = "✓" if inc else "✗"
-            print(f"\033[90m{name:<15} {pri:>6} {mark:>6} {length:>8}\033[0m")
-        total = sum(l for _, _, i, l in segment_info if i)
-        print(f"\033[90m{'总计':<15} {'':>6} {'':>6} {total:>8}\033[0m\n")
+        print(
+            f"\n\033[90m{'segment':<12} {'order':>5} {'value':>5} "
+            f"{'status':>9} {'chars':>7} source / reason\033[0m"
+        )
+        for decision in LAST_PROMPT_PLAN.decisions:
+            print(
+                f"\033[90m{decision.name:<12} {decision.priority:>5} "
+                f"{decision.budget_priority:>5} {decision.status:>9} "
+                f"{decision.rendered_chars:>7} {decision.provenance} / "
+                f"{decision.reason}\033[0m"
+            )
+        budget = "unbounded" if budget_chars is None else f"{budget_chars:,}"
+        print(
+            f"\033[90mused {LAST_PROMPT_PLAN.used_chars:,} / {budget} chars; "
+            f"dropped={list(LAST_PROMPT_PLAN.dropped_names)}\033[0m\n"
+        )
 
-    return "\n\n---\n\n".join(parts)
+    return LAST_PROMPT_PLAN.prompt
 
 
 # ======================================================================

--- a/s15_prompt_assembly/images/prompt-assembly.svg
+++ b/s15_prompt_assembly/images/prompt-assembly.svg
@@ -72,8 +72,8 @@
 
   <!-- Funnel -->
   <polygon points="50,230 750,230 600,290 200,290" fill="#e8f0fe" stroke="#1a73e8" stroke-width="2"/>
-  <text x="400" y="265" text-anchor="middle" font-size="14" fill="#1a73e8" font-weight="bold">运行时拼装 (Runtime Assembly)</text>
-  <text x="400" y="283" text-anchor="middle" font-size="11" fill="#202124">每次会话动态组合, 非静态模板</text>
+  <text x="400" y="260" text-anchor="middle" font-size="14" fill="#1a73e8" font-weight="bold">Context Budget Planner</text>
+  <text x="400" y="279" text-anchor="middle" font-size="11" fill="#202124">required 先保留 · optional 按价值选择 · 来源可追踪</text>
 
   <!-- Arrow down -->
   <line x1="400" y1="290" x2="400" y2="320" stroke="#1a73e8" stroke-width="2.5" marker-end="url(#arrowBlue)"/>
@@ -81,8 +81,8 @@
   <!-- Final System Prompt -->
   <rect x="150" y="325" width="500" height="70" rx="8" fill="#1a73e8"/>
   <text x="400" y="350" text-anchor="middle" font-size="16" fill="white" font-weight="bold">Final System Prompt</text>
-  <text x="400" y="370" text-anchor="middle" font-size="12" fill="#e8f0fe">= Persona + Memory + Profile + Skills + Expert + Tools + Hooks + ...</text>
-  <text x="400" y="387" text-anchor="middle" font-size="11" fill="#e8f0fe">组合后的完整系统提示词发送给 LLM</text>
+  <text x="400" y="370" text-anchor="middle" font-size="12" fill="#e8f0fe">预算内高价值片段按展示优先级拼接</text>
+  <text x="400" y="387" text-anchor="middle" font-size="11" fill="#e8f0fe">同时输出 included / dropped / inactive 决策</text>
 
   <!-- Arrow to LLM -->
   <line x1="400" y1="395" x2="400" y2="420" stroke="#202124" stroke-width="2" marker-end="url(#arrow)"/>
@@ -92,11 +92,11 @@
   <text x="400" y="453" text-anchor="middle" font-size="14" fill="white" font-weight="bold">→ LLM 推理</text>
 
   <!-- Notes -->
-  <text x="50" y="440" font-size="11" fill="#202124">✓ 按需加载: 只包含</text>
-  <text x="50" y="455" font-size="11" fill="#202124">  相关的段落</text>
-  <text x="50" y="470" font-size="11" fill="#202124">✓ 可缓存重复段落</text>
+  <text x="50" y="440" font-size="11" fill="#202124">✓ 安全规则 fail-closed</text>
+  <text x="50" y="455" font-size="11" fill="#202124">✓ Memory 整块取舍</text>
+  <text x="50" y="470" font-size="11" fill="#202124">✓ 计算分隔符成本</text>
 
-  <text x="580" y="440" font-size="11" fill="#202124">✓ 工具列表随配置变化</text>
-  <text x="580" y="455" font-size="11" fill="#202124">✓ 专家可替换整个段落</text>
-  <text x="580" y="470" font-size="11" fill="#202124">✓ 总长度受 token 限制</text>
+  <text x="580" y="440" font-size="11" fill="#202124">✓ 来源进入决策报告</text>
+  <text x="580" y="455" font-size="11" fill="#202124">✓ 展示顺序与价值分离</text>
+  <text x="580" y="470" font-size="11" fill="#202124">✓ 总长度不超过预算</text>
 </svg>

--- a/tests/test_prompt_budget.py
+++ b/tests/test_prompt_budget.py
@@ -1,0 +1,181 @@
+"""Offline contracts for s15's explainable context budget planner."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def s15(tmp_path_factory: pytest.TempPathFactory):
+    stub_dir = ROOT / "tests" / "stubs"
+    state_root = tmp_path_factory.mktemp("s15-import-state")
+    sys.path.insert(0, str(stub_dir))
+    saved_anthropic = sys.modules.pop("anthropic", None)
+    old_model = os.environ.get("MODEL_ID")
+    old_home = os.environ.get("WORKBUDDY_HOME")
+    os.environ["MODEL_ID"] = "offline-test-model"
+    os.environ["WORKBUDDY_HOME"] = str(state_root)
+    module_name = "s15_prompt_budget_test_module"
+    try:
+        spec = importlib.util.spec_from_file_location(
+            module_name, ROOT / "s15_prompt_assembly" / "code.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.path.remove(str(stub_dir))
+        sys.modules.pop(module_name, None)
+        sys.modules.pop("anthropic", None)
+        if saved_anthropic is not None:
+            sys.modules["anthropic"] = saved_anthropic
+        if old_model is None:
+            os.environ.pop("MODEL_ID", None)
+        else:
+            os.environ["MODEL_ID"] = old_model
+        if old_home is None:
+            os.environ.pop("WORKBUDDY_HOME", None)
+        else:
+            os.environ["WORKBUDDY_HOME"] = old_home
+
+
+def segment(s15, name: str, content: str | None, **kwargs):
+    return s15.PromptSegment(name, lambda: content, **kwargs)
+
+
+def test_required_segments_survive_and_render_in_presentation_order(s15) -> None:
+    segments = [
+        segment(s15, "mode", "MODE", priority=90, required=True),
+        segment(s15, "base", "BASE", priority=10, required=True),
+        segment(s15, "optional", "X" * 100, priority=20, budget_priority=100),
+    ]
+    required_prompt = "BASE" + s15.PROMPT_SEPARATOR + "MODE"
+
+    plan = s15.plan_prompt(segments, budget_chars=len(required_prompt))
+
+    assert plan.prompt == required_prompt
+    assert plan.included_names == ("base", "mode")
+    assert plan.dropped_names == ("optional",)
+    assert plan.used_chars == len(required_prompt)
+
+
+def test_budget_value_is_distinct_from_presentation_order(s15) -> None:
+    segments = [
+        segment(s15, "base", "B", priority=10, required=True),
+        segment(s15, "low-value-first", "LOW", priority=20, budget_priority=10),
+        segment(s15, "high-value-last", "HIGH", priority=80, budget_priority=90),
+    ]
+    budget = len("B" + s15.PROMPT_SEPARATOR + "HIGH")
+
+    plan = s15.plan_prompt(segments, budget_chars=budget)
+
+    assert plan.prompt == "B" + s15.PROMPT_SEPARATOR + "HIGH"
+    assert plan.included_names == ("base", "high-value-last")
+    assert plan.dropped_names == ("low-value-first",)
+
+
+def test_separator_cost_is_part_of_the_budget(s15) -> None:
+    segments = [
+        segment(s15, "base", "A", required=True),
+        segment(s15, "memory", "B", budget_priority=50),
+    ]
+
+    plan = s15.plan_prompt(segments, budget_chars=2)
+
+    assert plan.prompt == "A"
+    assert plan.dropped_names == ("memory",)
+
+
+def test_optional_memory_is_atomic_and_reports_provenance(s15) -> None:
+    memory = "<memory>trusted project decision</memory>"
+    segments = [
+        segment(
+            s15, "base", "BASE", required=True,
+            provenance="harness:base-rules",
+        ),
+        segment(
+            s15, "memory", memory, budget_priority=50,
+            provenance="workspace:curated-memory",
+        ),
+    ]
+
+    plan = s15.plan_prompt(segments, budget_chars=len("BASE"))
+    decision = next(item for item in plan.decisions if item.name == "memory")
+
+    assert memory not in plan.prompt
+    assert "trusted project" not in plan.prompt
+    assert decision.status == "dropped"
+    assert decision.rendered_chars == 0
+    assert decision.original_chars == len(memory)
+    assert decision.provenance == "workspace:curated-memory"
+    assert "budget" in decision.reason
+
+
+def test_inactive_segment_consumes_no_budget(s15) -> None:
+    inactive = s15.PromptSegment(
+        "expert", lambda: "SHOULD NOT BUILD",
+        condition=lambda: False,
+        provenance="runtime:expert",
+    )
+
+    plan = s15.plan_prompt([inactive], budget_chars=0)
+
+    assert plan.prompt == ""
+    assert plan.decisions[0].status == "inactive"
+    assert plan.decisions[0].provenance == "runtime:expert"
+
+
+def test_impossible_required_budget_fails_loudly(s15) -> None:
+    segments = [segment(s15, "base", "SAFETY", required=True)]
+
+    with pytest.raises(s15.PromptBudgetError, match="required prompt segments need"):
+        s15.plan_prompt(segments, budget_chars=1)
+
+
+def test_duplicate_segment_names_are_rejected(s15) -> None:
+    segments = [
+        segment(s15, "memory", "FIRST"),
+        segment(s15, "memory", "SECOND"),
+    ]
+
+    with pytest.raises(ValueError, match="duplicate prompt segment names: memory"):
+        s15.plan_prompt(segments, budget_chars=None)
+
+
+def test_unbounded_plan_preserves_backwards_compatible_assembly(s15) -> None:
+    segments = [
+        segment(s15, "second", "SECOND", priority=20, budget_priority=1),
+        segment(s15, "first", "FIRST", priority=10, budget_priority=1),
+    ]
+
+    plan = s15.plan_prompt(segments, budget_chars=None)
+
+    assert plan.prompt == "FIRST" + s15.PROMPT_SEPARATOR + "SECOND"
+    assert plan.dropped_names == ()
+
+
+def test_runtime_assembly_uses_configured_budget_and_exposes_last_plan(
+    s15, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    segments = [
+        segment(s15, "base", "BASE", required=True),
+        segment(s15, "optional", "OPTIONAL", budget_priority=1),
+    ]
+    monkeypatch.setattr(s15, "SEGMENTS", segments)
+    monkeypatch.setattr(s15, "PROMPT_BUDGET_CHARS", len("BASE"))
+
+    prompt = s15.assemble_system_prompt()
+
+    assert prompt == "BASE"
+    assert s15.LAST_PROMPT_PLAN is not None
+    assert s15.LAST_PROMPT_PLAN.dropped_names == ("optional",)


### PR DESCRIPTION
## Summary

- add an explainable context budget planner for s15 prompt assembly
- preserve required harness segments while selecting optional context by budget value
- retain provenance and report included, dropped, and inactive decisions
- update the lesson documentation and architecture diagram

## Validation

- `python -m pytest -q tests/test_prompt_budget.py tests/test_chapter_imports.py ...` (19 passed)
- `python -m py_compile s15_prompt_assembly/code.py`
- s15 interactive CLI and `--demo` smoke checks
- SVG XML validation and `git diff --check`

## Notes

The planner uses deterministic character budgets for the offline lesson. A production adapter can replace the length function with a model tokenizer while preserving the required/value/provenance contract.
