### PR TITLE
feat(s10): add workspace memory supersession

### DIFF
--- a/s10_workspace_memory/README.md
+++ b/s10_workspace_memory/README.md
@@ -13,11 +13,15 @@ flowchart LR
     A["Tool / Agent outcome"] --> B["validate MemoryFact"]
     B --> C["daily/*.jsonl append"]
     C --> D["DistillPolicy gate"]
-    D -->|"important or repeated"| E["curated.json"]
+    D -->|"important or repeated"| E["group by memory_key"]
     D -->|"not stable"| C
-    E --> F["MEMORY.md projection"]
+    E --> H{"one strongest newer value?"}
+    H -->|"yes"| I["new active revision"]
+    H -->|"tie / stale"| C
+    I --> J["curated.json history"]
+    J --> F["active-only MEMORY.md"]
     F --> G["bounded prompt context"]
-    C -. "evidence retained" .-> E
+    C -. "evidence retained" .-> J
 ```
 
 ## 本章设计目标
@@ -27,6 +31,8 @@ s09 的 JSONL transcript 属于某个 session，是完整执行证据；本章�
 - 同一项目的不同会话可以恢复同一份记忆；不同项目绝不串线。
 - 原始事实只追加，蒸馏不会删除证据。
 - 只有稳定、足够旧且重要或重复出现的事实进入长期视图。
+- 可替换的项目决策使用显式 `memory_key` 形成冲突域，新值只会在重复确认且时间更新时替代旧值。
+- 被替代的修订和原始证据继续保留，prompt 只注入每个冲突域的 active 修订。
 - 策展状态通过原子替换更新，失败时仍保留上一份完整文件。
 - 不依赖 API key 就能验证记忆策略。
 
@@ -64,6 +70,7 @@ memory.append_daily_log(
     "SQLite must run in WAL mode.",
     kind=FactKind.DECISION,
     importance=5,
+    memory_key="storage.sqlite.journal-mode",
     source="agent",
     evidence={"file": "storage.py"},
 )
@@ -80,6 +87,8 @@ memory.append_daily_log(
 
 内容、重要度和类型在持久化之前验证。每个 JSON 对象编码为一行，再以一次 `os.write` 追加；成功返回前执行 `fsync`。
 
+`memory_key` 是可选的、由 harness 或工具调用者显式提供的稳定冲突域，只允许小写单词以及 `.`、`_`、`-` 分隔符，例如 `runtime.python-version`。它描述“这条记忆回答哪个问题”，而不是答案本身：`Use Python 3.11` 和 `Use Python 3.12` 可以共享同一个 key。未设置该字段的旧调用继续使用内容派生 key，不会被升级过程猜测或合并。
+
 ### 2. 通过显式策略蒸馏
 
 默认策略的逻辑是：
@@ -92,7 +101,15 @@ AND (importance >= 4 OR 规范化后重复出现 >= 2 次)
 
 这套规则刻意不让 LLM 直接决定“什么值得永远记住”。生产系统可以在候选提取阶段使用模型，但保留条件、作用域和证据关系仍应由 harness 控制。
 
-每条策展记忆的 key 由 `kind + 规范化内容` 稳定生成，`evidence_ids` 指向原始事实。因此重复运行 distill 是幂等的，新证据只会更新同一个条目。
+无 `memory_key` 的策展记忆仍由 `kind + 规范化内容` 生成稳定 key。显式 keyed 记忆则先按 `memory_key` 建立冲突域，再按以下规则处理：
+
+1. 与 active 内容相同的新事实只合并 `evidence_ids`，不会产生新修订。
+2. 不同内容必须同时通过普通晋升门槛，并至少有 `supersession_repeat_threshold` 条独立事实确认；默认值为 2，即单条高重要度事实也不能直接覆盖现有决策。
+3. 候选的最新时间必须晚于 active 修订的 `last_seen`，过期证据不能回滚当前值。
+4. 多个候选按重要度、独立证据数和最新时间排序；最优分数相同时 fail closed，保留当前修订并在报告中增加 `conflicts`。
+5. 唯一胜出者成为下一版 active 修订；旧版标记为 `superseded`，双方通过 `supersedes` / `superseded_by` 互相指向。
+
+每条修订都保留 `revision` 和 `evidence_ids`，因此重复运行 `distill` 是幂等的，完整决策历史也可审计。`DistillReport` 额外报告 `superseded`、`conflicts` 与 `stale`，让拒绝覆盖的原因可观察。
 
 ### 3. 保留原始证据
 
@@ -119,6 +136,8 @@ Windows 的回退仍会在替换前完整写入、刷新并同步临时文件，
 
 `curated.json` 是 canonical state，`MEMORY.md` 是可重建投影。如果进程在两次替换之间退出，下一次读取会以 canonical state 修复陈旧投影。新建一个 `WorkspaceMemory(project_dir)` 实例即可从磁盘恢复事实、策展条目和 prompt context；不会反序列化任何进程内对象。
 
+当前 schema 为 v2；读取器仍接受 v1 daily fact 和 curated state。旧条目按无 key 的 legacy 语义恢复，在下一次成功蒸馏写入时统一保存为 v2，而不会自动推断冲突域。读取 keyed 状态时还会校验每个域恰好一个 active 修订、修订号连续、前后链接互相匹配；损坏状态会显式报错，不会静默选择一个答案。
+
 ## Prompt 注入边界
 
 `get_context_for_agent()` 只注入两部分：
@@ -126,7 +145,7 @@ Windows 的回退仍会在替换前完整写入、刷新并同步临时文件，
 - 紧凑的 `MEMORY.md`；
 - 最近最多 6 条 workspace facts。
 
-它不会把所有 daily log 或 session transcript 整体塞回上下文。Memory 的价值不在“存得越多”，而在召回时有明确预算和优先级。
+它不会把所有 daily log 或 session transcript 整体塞回上下文。Keyed 原始事实在完成蒸馏前也不会作为 recent facts 绕过冲突策略；prompt 只能看到每个冲突域当前的 active 修订。Memory 的价值不在“存得越多”，而在召回时有明确预算和优先级。
 
 `MemoryAwareAgent` 在每个模型回合前读取这个 bounded view，并提供结构化 `write_memory` 工具。是否继续工具循环由响应中的 `tool_use` block 决定，不依赖 provider 的某个 stop-reason 字符串。
 
@@ -134,16 +153,17 @@ Windows 的回退仍会在替换前完整写入、刷新并同步临时文件，
 
 ```text
 append_daily_log
-  -> validate kind / importance / content
+  -> validate kind / importance / content / optional memory_key
   -> attach workspace_id + fact_id + UTC timestamp
   -> append one JSONL record + fsync
 
 distill
   -> load facts older than cutoff
   -> reject unstable kinds
-  -> group normalized repeated facts
+  -> preserve legacy content groups; group keyed facts by conflict domain
   -> apply importance/repetition gate
-  -> merge by deterministic key and evidence id
+  -> reject stale or tied challengers
+  -> merge evidence or append a linked revision
   -> atomically replace curated.json and MEMORY.md
 
 restart
@@ -167,7 +187,7 @@ python3 s10_workspace_memory/code.py --demo
 python3 -m pytest -q tests/test_workspace_memory.py
 ```
 
-测试覆盖：项目隔离、追加顺序、蒸馏门槛、幂等、证据保留、原子替换失败和跨实例恢复。
+测试覆盖：项目隔离、追加顺序、蒸馏门槛、幂等、证据保留、原子替换失败、key 校验、新值确认、冲突 fail closed、过期证据防回滚、修订链校验、v1 迁移和跨实例恢复。
 
 配置模型后可运行交互路径：
 
@@ -189,11 +209,14 @@ python3 s10_workspace_memory/code.py
 - **直接覆盖策展文件**：崩溃可能损坏长期状态。
 - **只按字符串路径隔离**：相对路径、软链接可能让同一项目得到多个 scope。
 - **把一次测试通过写成长期规则**：outcome 应留在近期日志，不自动晋升。
+- **用答案文本充当 `memory_key`**：值改变时会变成另一个冲突域，失去替代关系；key 应描述稳定问题，例如 `runtime.python-version`。
+- **让单条新事实覆盖已有决策**：高重要度不等于已确认，替代必须满足独立重复证据门槛。
+- **把所有候选都注入 prompt 再让模型选择**：这会绕过 harness 的冲突策略；未决候选应留在证据日志中。
 
 ## 练习
 
 1. 为 `DistillPolicy` 增加来源置信度，让用户确认的事实比工具推断更容易晋升。
-2. 为 curated entry 增加 supersedes 关系，处理“旧决策被新决策替代”。
+2. 为冲突报告增加待人工裁决队列，并设计显式选择某个候选的审计记录。
 3. 在不加载全部日志的前提下实现按日期倒序读取最近事实。
 
 ## 下一课

--- a/s10_workspace_memory/code.py
+++ b/s10_workspace_memory/code.py
@@ -40,6 +40,7 @@ PROGRESSION = {
     "adds": [
         "workspace-scoped fact log",
         "policy-driven memory distillation",
+        "keyed memory supersession",
         "atomic curated memory view",
     ],
     "preserves": ["append-only evidence and restart recovery"],
@@ -76,10 +77,14 @@ if os.getenv("ANTHROPIC_BASE_URL"):
     os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+SUPPORTED_FACT_SCHEMAS = frozenset({1, SCHEMA_VERSION})
+SUPPORTED_CURATED_SCHEMAS = frozenset({1, SCHEMA_VERSION})
 DEFAULT_RETENTION_DAYS = 30
 MAX_FACT_CHARS = 2_000
 MAX_CONTEXT_FACTS = 6
+MAX_MEMORY_KEY_CHARS = 120
+MEMORY_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
 WORKDIR = Path.cwd()
 _DIRECTORY_FSYNC_SUPPORTED = os.name != "nt"
 
@@ -128,6 +133,13 @@ class FactKind(str, Enum):
     OUTCOME = "outcome"
 
 
+class CuratedStatus(str, Enum):
+    """Lifecycle state for one immutable curated revision."""
+
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+
+
 @dataclass(frozen=True)
 class MemoryFact:
     """One immutable fact in a workspace's append-only daily log."""
@@ -141,6 +153,7 @@ class MemoryFact:
     importance: int = 3
     evidence: Mapping[str, str] = field(default_factory=dict)
     schema_version: int = SCHEMA_VERSION
+    memory_key: str | None = None
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, object]) -> "MemoryFact":
@@ -151,6 +164,11 @@ class MemoryFact:
                 recorded_at=str(payload["recorded_at"]),
                 kind=str(payload["kind"]),
                 content=str(payload["content"]),
+                memory_key=(
+                    None
+                    if payload.get("memory_key") in (None, "")
+                    else _clean_memory_key(str(payload["memory_key"]))
+                ),
                 source=str(payload.get("source", "agent")),
                 importance=int(payload.get("importance", 3)),
                 evidence=dict(payload.get("evidence") or {}),
@@ -167,6 +185,7 @@ class DistillPolicy:
     minimum_age_days: int = DEFAULT_RETENTION_DAYS
     minimum_importance: int = 4
     repeat_threshold: int = 2
+    supersession_repeat_threshold: int = 2
     stable_kinds: frozenset[str] = frozenset(
         {FactKind.DECISION.value, FactKind.CONVENTION.value, FactKind.PITFALL.value}
     )
@@ -178,6 +197,8 @@ class DistillPolicy:
             raise ValueError("minimum_importance must be between 1 and 5")
         if self.repeat_threshold < 1:
             raise ValueError("repeat_threshold must be >= 1")
+        if self.supersession_repeat_threshold < 2:
+            raise ValueError("supersession_repeat_threshold must be >= 2")
 
 
 @dataclass
@@ -191,11 +212,27 @@ class CuratedMemoryEntry:
     last_seen: str
     evidence_ids: list[str]
     occurrences: int
+    memory_key: str | None = None
+    revision: int = 1
+    status: str = CuratedStatus.ACTIVE.value
+    supersedes: str | None = None
+    superseded_by: str | None = None
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, object]) -> "CuratedMemoryEntry":
         try:
             evidence_ids = [str(item) for item in payload.get("evidence_ids", [])]
+            memory_key = payload.get("memory_key")
+            if memory_key not in (None, ""):
+                memory_key = _clean_memory_key(str(memory_key))
+            else:
+                memory_key = None
+            revision = int(payload.get("revision", 1))
+            status = str(payload.get("status", CuratedStatus.ACTIVE.value))
+            if revision < 1:
+                raise ValueError("revision must be >= 1")
+            if status not in {item.value for item in CuratedStatus}:
+                raise ValueError(f"unsupported curated status: {status}")
             return cls(
                 key=str(payload["key"]),
                 kind=str(payload["kind"]),
@@ -204,6 +241,19 @@ class CuratedMemoryEntry:
                 last_seen=str(payload["last_seen"]),
                 evidence_ids=evidence_ids,
                 occurrences=int(payload.get("occurrences", len(evidence_ids))),
+                memory_key=memory_key,
+                revision=revision,
+                status=status,
+                supersedes=(
+                    None
+                    if payload.get("supersedes") in (None, "")
+                    else str(payload["supersedes"])
+                ),
+                superseded_by=(
+                    None
+                    if payload.get("superseded_by") in (None, "")
+                    else str(payload["superseded_by"])
+                ),
             )
         except (KeyError, TypeError, ValueError) as exc:
             raise MemoryCorruptionError(f"invalid curated entry: {exc}") from exc
@@ -218,6 +268,9 @@ class DistillReport:
     created: int
     updated: int
     skipped: int
+    superseded: int = 0
+    conflicts: int = 0
+    stale: int = 0
 
 
 def _as_utc(value: datetime | None) -> datetime:
@@ -241,9 +294,49 @@ def _normal_form(content: str) -> str:
     return re.sub(r"\s+", " ", content).strip().casefold()
 
 
-def _entry_key(kind: str, content: str) -> str:
-    material = f"{kind}\0{_normal_form(content)}".encode("utf-8")
-    return hashlib.sha256(material).hexdigest()[:16]
+def _clean_memory_key(value: str) -> str:
+    """Normalize one explicit conflict domain before it reaches durable state."""
+
+    key = value.strip().casefold()
+    if not key:
+        raise ValueError("memory_key must not be empty")
+    if len(key) > MAX_MEMORY_KEY_CHARS:
+        raise ValueError(f"memory_key exceeds {MAX_MEMORY_KEY_CHARS} characters")
+    if not MEMORY_KEY_PATTERN.fullmatch(key):
+        raise ValueError(
+            "memory_key must use lowercase words separated by '.', '_' or '-'"
+        )
+    return key
+
+
+def _entry_key(
+    kind: str,
+    content: str,
+    *,
+    memory_key: str | None = None,
+    revision: int = 1,
+) -> str:
+    if memory_key is None:
+        material = f"{kind}\0{_normal_form(content)}"
+    else:
+        material = (
+            f"{memory_key}\0revision:{revision}\0{kind}\0{_normal_form(content)}"
+        )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+def _proposal_signature(fact: MemoryFact) -> tuple[str, str]:
+    return fact.kind, _normal_form(fact.content)
+
+
+def _proposal_score(facts: list[MemoryFact]) -> tuple[int, int, datetime]:
+    """Prefer stronger evidence; use recency only after importance and count."""
+
+    return (
+        max(fact.importance for fact in facts),
+        len({fact.fact_id for fact in facts}),
+        max(_parse_timestamp(fact.recorded_at) for fact in facts),
+    )
 
 
 class WorkspaceMemory:
@@ -289,6 +382,7 @@ class WorkspaceMemory:
         importance: int = 3,
         source: str = "agent",
         evidence: Mapping[str, str] | None = None,
+        memory_key: str | None = None,
         recorded_at: datetime | None = None,
         fact_id: str | None = None,
     ) -> MemoryFact:
@@ -314,12 +408,16 @@ class WorkspaceMemory:
             raise ValueError(f"unknown fact kind: {kind_value}")
 
         timestamp = _as_utc(recorded_at)
+        normalized_memory_key = (
+            None if memory_key is None else _clean_memory_key(memory_key)
+        )
         fact = MemoryFact(
             fact_id=fact_id or uuid.uuid4().hex,
             workspace_id=self.workspace_id,
             recorded_at=timestamp.isoformat().replace("+00:00", "Z"),
             kind=kind_value,
             content=text,
+            memory_key=normalized_memory_key,
             source=source,
             importance=importance,
             evidence=dict(evidence or {}),
@@ -358,7 +456,7 @@ class WorkspaceMemory:
                     break
                 raise MemoryCorruptionError(f"{path.name}:{index}: invalid JSON") from exc
             fact = MemoryFact.from_dict(payload)
-            if fact.schema_version != SCHEMA_VERSION:
+            if fact.schema_version not in SUPPORTED_FACT_SCHEMAS:
                 raise MemoryCorruptionError(
                     f"{path.name}:{index}: unsupported schema {fact.schema_version}"
                 )
@@ -411,15 +509,100 @@ class WorkspaceMemory:
             raise MemoryCorruptionError("curated.json is not valid JSON") from exc
         if payload.get("workspace_id") != self.workspace_id:
             raise MemoryScopeError("curated memory belongs to another workspace")
-        if payload.get("schema_version") != SCHEMA_VERSION:
+        if payload.get("schema_version") not in SUPPORTED_CURATED_SCHEMAS:
             raise MemoryCorruptionError("unsupported curated memory schema")
-        return [CuratedMemoryEntry.from_dict(item) for item in payload.get("entries", [])]
+        entries = [
+            CuratedMemoryEntry.from_dict(item)
+            for item in payload.get("entries", [])
+        ]
+        self._validate_curated(entries)
+        return entries
+
+    @staticmethod
+    def _validate_curated(entries: list[CuratedMemoryEntry]) -> None:
+        """Reject ambiguous or broken lifecycle graphs before prompt projection."""
+
+        by_key = {entry.key: entry for entry in entries}
+        if len(by_key) != len(entries):
+            raise MemoryCorruptionError("curated entry keys must be unique")
+        active_by_memory_key: dict[str, CuratedMemoryEntry] = {}
+        for entry in entries:
+            if entry.occurrences != len(set(entry.evidence_ids)):
+                raise MemoryCorruptionError(
+                    f"curated entry {entry.key} has inconsistent evidence count"
+                )
+            if entry.memory_key is None:
+                if (
+                    entry.revision != 1
+                    or entry.status != CuratedStatus.ACTIVE.value
+                    or entry.supersedes
+                    or entry.superseded_by
+                ):
+                    raise MemoryCorruptionError(
+                        f"legacy entry {entry.key} cannot have revision lifecycle"
+                    )
+                continue
+            if entry.memory_key is not None and entry.status == CuratedStatus.ACTIVE.value:
+                previous = active_by_memory_key.get(entry.memory_key)
+                if previous is not None:
+                    raise MemoryCorruptionError(
+                        f"multiple active revisions for memory_key {entry.memory_key}"
+                    )
+                active_by_memory_key[entry.memory_key] = entry
+            if entry.status == CuratedStatus.ACTIVE.value and entry.superseded_by:
+                raise MemoryCorruptionError(
+                    f"active entry {entry.key} cannot have superseded_by"
+                )
+            if entry.status == CuratedStatus.SUPERSEDED.value and not entry.superseded_by:
+                raise MemoryCorruptionError(
+                    f"superseded entry {entry.key} needs superseded_by"
+                )
+            if entry.revision == 1 and entry.supersedes:
+                raise MemoryCorruptionError(
+                    f"first revision {entry.key} cannot supersede another entry"
+                )
+            if entry.revision > 1 and not entry.supersedes:
+                raise MemoryCorruptionError(
+                    f"revision {entry.key} needs a supersedes link"
+                )
+        keyed_domains = {
+            entry.memory_key for entry in entries if entry.memory_key is not None
+        }
+        missing_active = sorted(keyed_domains - set(active_by_memory_key))
+        if missing_active:
+            raise MemoryCorruptionError(
+                "curated lifecycle has no active revision for: "
+                + ", ".join(missing_active)
+            )
+        for entry in entries:
+            if entry.superseded_by:
+                successor = by_key.get(entry.superseded_by)
+                if successor is None or successor.supersedes != entry.key:
+                    raise MemoryCorruptionError(
+                        f"entry {entry.key} has a broken superseded_by link"
+                    )
+            if entry.supersedes:
+                previous = by_key.get(entry.supersedes)
+                if previous is None or previous.superseded_by != entry.key:
+                    raise MemoryCorruptionError(
+                        f"entry {entry.key} has a broken supersedes link"
+                    )
+                if previous.memory_key != entry.memory_key:
+                    raise MemoryCorruptionError(
+                        f"entry {entry.key} supersedes another conflict domain"
+                    )
+                if entry.revision != previous.revision + 1:
+                    raise MemoryCorruptionError(
+                        f"entry {entry.key} has a non-contiguous revision"
+                    )
 
     def _render_memory(self, entries: Iterable[CuratedMemoryEntry]) -> str:
         groups: dict[str, list[CuratedMemoryEntry]] = {
             kind.value: [] for kind in FactKind if kind is not FactKind.OUTCOME
         }
         for entry in entries:
+            if entry.status != CuratedStatus.ACTIVE.value:
+                continue
             groups.setdefault(entry.kind, []).append(entry)
 
         labels = {
@@ -450,7 +633,16 @@ class WorkspaceMemory:
         return "\n".join(lines)
 
     def _save_curated(self, entries: list[CuratedMemoryEntry]) -> None:
-        ordered = sorted(entries, key=lambda item: (item.kind, item.key))
+        self._validate_curated(entries)
+        ordered = sorted(
+            entries,
+            key=lambda item: (
+                item.kind,
+                item.memory_key or "",
+                item.revision,
+                item.key,
+            ),
+        )
         payload = {
             "schema_version": SCHEMA_VERSION,
             "workspace_id": self.workspace_id,
@@ -486,10 +678,11 @@ class WorkspaceMemory:
     ) -> DistillReport:
         """Promote eligible facts without deleting their source evidence.
 
-        A stable fact becomes long-term memory when it is old enough and is
-        either explicitly important or independently repeated.  Existing
-        evidence ids make reruns idempotent.  Repeated observations update the
-        same deterministic entry instead of producing near-duplicate bullets.
+        Unkeyed facts preserve the original content-based behavior.  Facts
+        with ``memory_key`` share one conflict domain: repeated, newer evidence
+        may create a new active revision while the old revision and all source
+        facts remain available for audit.  Equal-strength proposals fail
+        closed instead of depending on filesystem or dictionary order.
         """
 
         active_policy = policy or DistillPolicy()
@@ -510,23 +703,48 @@ class WorkspaceMemory:
             for fact in aged
             if fact.kind in active_policy.stable_kinds and fact.fact_id not in processed_ids
         ]
-        groups: dict[str, list[MemoryFact]] = {}
-        for fact in candidates:
-            groups.setdefault(_entry_key(fact.kind, fact.content), []).append(fact)
 
         created = 0
         updated = 0
         eligible = 0
         skipped = len(aged) - len(candidates)
+        superseded = 0
+        conflicts = 0
+        stale = 0
         changed = False
-        for key, facts in groups.items():
-            current = by_key.get(key)
-            qualifies = (
-                current is not None
-                or max(fact.importance for fact in facts) >= active_policy.minimum_importance
+
+        def distinct(facts: list[MemoryFact]) -> list[MemoryFact]:
+            return list({fact.fact_id: fact for fact in facts}.values())
+
+        def qualifies(facts: list[MemoryFact]) -> bool:
+            return (
+                max(fact.importance for fact in facts)
+                >= active_policy.minimum_importance
                 or len(facts) >= active_policy.repeat_threshold
             )
-            if not qualifies:
+
+        def representative(facts: list[MemoryFact]) -> MemoryFact:
+            return max(
+                facts,
+                key=lambda fact: (
+                    fact.importance,
+                    _parse_timestamp(fact.recorded_at),
+                    fact.fact_id,
+                ),
+            )
+
+        # Legacy facts intentionally keep their original content-derived key.
+        # An upgrade must not infer conflict domains for existing workspaces.
+        legacy_groups: dict[str, list[MemoryFact]] = {}
+        for fact in candidates:
+            if fact.memory_key is None:
+                legacy_groups.setdefault(
+                    _entry_key(fact.kind, fact.content), []
+                ).append(fact)
+        for key in sorted(legacy_groups):
+            facts = distinct(legacy_groups[key])
+            current = by_key.get(key)
+            if current is None and not qualifies(facts):
                 skipped += len(facts)
                 continue
 
@@ -534,14 +752,20 @@ class WorkspaceMemory:
             timestamps = sorted(fact.recorded_at for fact in facts)
             new_ids = {fact.fact_id for fact in facts}
             if current is None:
-                representative = sorted(
+                # Preserve the original legacy projection: importance first,
+                # then the earliest stable wording for deterministic display.
+                chosen = min(
                     facts,
-                    key=lambda fact: (-fact.importance, fact.recorded_at, fact.fact_id),
-                )[0]
+                    key=lambda fact: (
+                        -fact.importance,
+                        _parse_timestamp(fact.recorded_at),
+                        fact.fact_id,
+                    ),
+                )
                 by_key[key] = CuratedMemoryEntry(
                     key=key,
-                    kind=representative.kind,
-                    content=representative.content,
+                    kind=chosen.kind,
+                    content=chosen.content,
                     first_seen=timestamps[0],
                     last_seen=timestamps[-1],
                     evidence_ids=sorted(new_ids),
@@ -557,6 +781,122 @@ class WorkspaceMemory:
                 updated += 1
             changed = True
 
+        active_by_memory_key = {
+            entry.memory_key: entry
+            for entry in existing
+            if entry.memory_key is not None
+            and entry.status == CuratedStatus.ACTIVE.value
+        }
+        keyed_groups: dict[
+            str, dict[tuple[str, str], list[MemoryFact]]
+        ] = {}
+        for fact in candidates:
+            if fact.memory_key is None:
+                continue
+            proposals = keyed_groups.setdefault(fact.memory_key, {})
+            proposals.setdefault(_proposal_signature(fact), []).append(fact)
+
+        for memory_key in sorted(keyed_groups):
+            proposals = {
+                signature: distinct(facts)
+                for signature, facts in keyed_groups[memory_key].items()
+            }
+            current = active_by_memory_key.get(memory_key)
+
+            # More evidence for the current value is an idempotent update, not
+            # a new revision.  It also advances last_seen before challengers
+            # are checked, preventing older evidence from rolling it back.
+            if current is not None:
+                current_signature = (current.kind, _normal_form(current.content))
+                reinforcing = proposals.pop(current_signature, None)
+                if reinforcing:
+                    timestamps = sorted(fact.recorded_at for fact in reinforcing)
+                    new_ids = {fact.fact_id for fact in reinforcing}
+                    current.first_seen = min(current.first_seen, timestamps[0])
+                    current.last_seen = max(current.last_seen, timestamps[-1])
+                    current.evidence_ids = sorted(
+                        set(current.evidence_ids) | new_ids
+                    )
+                    current.occurrences = len(current.evidence_ids)
+                    eligible += len(reinforcing)
+                    updated += 1
+                    changed = True
+
+            qualified: list[tuple[tuple[str, str], list[MemoryFact]]] = []
+            for signature, facts in proposals.items():
+                if not qualifies(facts):
+                    skipped += len(facts)
+                    continue
+                if current is not None:
+                    if len(facts) < active_policy.supersession_repeat_threshold:
+                        skipped += len(facts)
+                        continue
+                    latest = max(
+                        _parse_timestamp(fact.recorded_at) for fact in facts
+                    )
+                    if latest <= _parse_timestamp(current.last_seen):
+                        skipped += len(facts)
+                        stale += len(facts)
+                        continue
+                qualified.append((signature, facts))
+
+            if not qualified:
+                continue
+
+            best_score = max(_proposal_score(facts) for _signature, facts in qualified)
+            winners = [
+                (signature, facts)
+                for signature, facts in qualified
+                if _proposal_score(facts) == best_score
+            ]
+            if len(winners) != 1:
+                conflicts += 1
+                skipped += sum(len(facts) for _signature, facts in qualified)
+                continue
+
+            winning_signature, winning_facts = winners[0]
+            skipped += sum(
+                len(facts)
+                for signature, facts in qualified
+                if signature != winning_signature
+            )
+            chosen = representative(winning_facts)
+            timestamps = sorted(fact.recorded_at for fact in winning_facts)
+            new_ids = sorted({fact.fact_id for fact in winning_facts})
+            revision = 1 if current is None else current.revision + 1
+            key = _entry_key(
+                chosen.kind,
+                chosen.content,
+                memory_key=memory_key,
+                revision=revision,
+            )
+            if key in by_key:
+                raise MemoryCorruptionError(
+                    f"curated revision key collision for {memory_key}"
+                )
+            entry = CuratedMemoryEntry(
+                key=key,
+                kind=chosen.kind,
+                content=chosen.content,
+                first_seen=timestamps[0],
+                last_seen=timestamps[-1],
+                evidence_ids=new_ids,
+                occurrences=len(new_ids),
+                memory_key=memory_key,
+                revision=revision,
+                status=CuratedStatus.ACTIVE.value,
+                supersedes=None if current is None else current.key,
+            )
+            if current is not None:
+                current.status = CuratedStatus.SUPERSEDED.value
+                current.superseded_by = entry.key
+                superseded += 1
+            by_key[entry.key] = entry
+            active_by_memory_key[memory_key] = entry
+            eligible += len(winning_facts)
+            created += 1
+            changed = True
+
         if changed:
             self._save_curated(list(by_key.values()))
 
@@ -566,6 +906,9 @@ class WorkspaceMemory:
             created=created,
             updated=updated,
             skipped=skipped,
+            superseded=superseded,
+            conflicts=conflicts,
+            stale=stale,
         )
 
     def get_context_for_agent(self, *, recent_limit: int = MAX_CONTEXT_FACTS) -> str:
@@ -576,7 +919,13 @@ class WorkspaceMemory:
         if curated:
             parts.append(curated)
 
-        recent = self.read_all_facts()[-recent_limit:] if recent_limit > 0 else []
+        # Explicitly keyed facts belong to the curated lifecycle.  Projecting
+        # raw challengers here would bypass the evidence threshold and expose
+        # conflicting values before distillation resolves them.
+        recent_candidates = [
+            fact for fact in self.read_all_facts() if fact.memory_key is None
+        ]
+        recent = recent_candidates[-recent_limit:] if recent_limit > 0 else []
         if recent:
             lines = ["# Recent Workspace Facts", ""]
             lines.extend(
@@ -616,7 +965,9 @@ class MemoryAwareAgent:
 
 Use write_memory only for durable project decisions, conventions, pitfalls,
 or completed outcomes. Do not store greetings, guesses, secrets, or raw tool
-output. Memory supplements the user-facing reply; it never replaces it."""
+output. Set memory_key for a replaceable project decision so later evidence
+can supersede it safely. Memory supplements the user-facing reply; it never
+replaces it."""
 
     @staticmethod
     def _build_tools() -> list[dict]:
@@ -645,6 +996,15 @@ output. Memory supplements the user-facing reply; it never replaces it."""
                             "type": "integer",
                             "minimum": 1,
                             "maximum": 5,
+                        },
+                        "memory_key": {
+                            "type": "string",
+                            "description": (
+                                "Optional stable conflict domain such as "
+                                "runtime.python-version"
+                            ),
+                            "pattern": MEMORY_KEY_PATTERN.pattern,
+                            "maxLength": MAX_MEMORY_KEY_CHARS,
                         },
                     },
                     "required": ["content", "kind", "importance"],
@@ -686,6 +1046,11 @@ output. Memory supplements the user-facing reply; it never replaces it."""
                         kind=str(block.input.get("kind", FactKind.OUTCOME.value)),
                         importance=int(block.input.get("importance", 3)),
                         source="model_tool",
+                        memory_key=(
+                            None
+                            if block.input.get("memory_key") in (None, "")
+                            else str(block.input["memory_key"])
+                        ),
                     )
                     output = f"memory fact appended: {fact.fact_id}"
                 elif block.name == "bash":
@@ -726,7 +1091,8 @@ def _print_report(report: DistillReport) -> None:
     print(
         "distill: "
         f"scanned={report.scanned}, eligible={report.eligible}, "
-        f"created={report.created}, updated={report.updated}, skipped={report.skipped}"
+        f"created={report.created}, updated={report.updated}, skipped={report.skipped}, "
+        f"superseded={report.superseded}, conflicts={report.conflicts}, stale={report.stale}"
     )
 
 

--- a/s10_workspace_memory/images/workspace-memory.svg
+++ b/s10_workspace_memory/images/workspace-memory.svg
@@ -1,81 +1,74 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" font-family="sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" role="img" aria-labelledby="title desc">
+  <title id="title">工作区记忆的蒸馏、冲突处理与修订链</title>
+  <desc id="desc">原始事实追加到日志，经门槛和 memory key 冲突域处理后形成可审计修订链，只有 active 修订进入 MEMORY.md 和 prompt。</desc>
   <defs>
-    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
-      <path d="M0,0 L10,5 L0,10 z" fill="#202124"/>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M1 1L9 5L1 9" fill="none" stroke="context-stroke" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-    <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
-      <path d="M0,0 L10,5 L0,10 z" fill="#1a73e8"/>
-    </marker>
+    <style>
+      .title{font:600 22px system-ui,sans-serif;fill:#172033}
+      .heading{font:600 15px system-ui,sans-serif;fill:#172033}
+      .body{font:400 13px system-ui,sans-serif;fill:#3b465d}
+      .small{font:400 12px system-ui,sans-serif;fill:#5d687d}
+      .mono{font:500 12px ui-monospace,monospace;fill:#3b465d}
+      .line{fill:none;stroke:#64748b;stroke-width:1.8;marker-end:url(#arrow)}
+      .dash{fill:none;stroke:#64748b;stroke-width:1.5;stroke-dasharray:5 5;marker-end:url(#arrow)}
+    </style>
   </defs>
-  <rect width="800" height="500" fill="#f8f9fa"/>
+  <rect width="960" height="560" fill="#f8fafc"/>
+  <text class="title" x="480" y="38" text-anchor="middle">Workspace Memory：可审计的替代与冲突处理</text>
 
-  <text x="400" y="35" text-anchor="middle" font-size="22" font-weight="bold" fill="#202124">工作区记忆系统</text>
+  <rect x="35" y="75" width="215" height="150" rx="12" fill="#e7f5ec" stroke="#3f9b69"/>
+  <text class="heading" x="55" y="105">daily/*.jsonl</text>
+  <text class="body" x="55" y="130">原始事实只追加</text>
+  <text class="body" x="55" y="153">保留时间与 evidence id</text>
+  <text class="body" x="55" y="176">可选稳定 memory_key</text>
+  <text class="mono" x="55" y="202">runtime.python-version</text>
 
-  <!-- Directory tree -->
-  <rect x="50" y="55" width="350" height="300" rx="8" fill="#e8f0fe" stroke="#1a73e8" stroke-width="2"/>
-  <rect x="50" y="55" width="350" height="35" rx="8" fill="#1a73e8"/>
-  <rect x="50" y="72" width="350" height="18" fill="#1a73e8"/>
-  <text x="225" y="77" text-anchor="middle" font-size="14" fill="white" font-weight="bold">.learn_workbuddy/memory/</text>
+  <rect x="295" y="75" width="215" height="150" rx="12" fill="#eaf2ff" stroke="#4f7fc7"/>
+  <text class="heading" x="315" y="105">DistillPolicy</text>
+  <text class="body" x="315" y="130">年龄、类型与重要度门槛</text>
+  <text class="body" x="315" y="153">替代需要至少 2 条新证据</text>
+  <text class="body" x="315" y="176">拒绝过期候选</text>
+  <text class="body" x="315" y="199">同分冲突 fail closed</text>
 
-  <text x="75" y="115" font-size="13" fill="#202124" font-family="monospace">memory/</text>
+  <rect x="555" y="75" width="370" height="150" rx="12" fill="#fff4df" stroke="#c98720"/>
+  <text class="heading" x="575" y="105">curated.json：canonical history</text>
+  <rect x="575" y="125" width="140" height="72" rx="8" fill="#f3e5ce" stroke="#ac7d39"/>
+  <text class="small" x="645" y="146" text-anchor="middle">revision 1</text>
+  <text class="body" x="645" y="168" text-anchor="middle">superseded</text>
+  <text class="small" x="645" y="187" text-anchor="middle">Python 3.11</text>
+  <path class="line" d="M715 161H777"/>
+  <text class="small" x="746" y="148" text-anchor="middle">supersedes</text>
+  <rect x="780" y="125" width="125" height="72" rx="8" fill="#ffe0a8" stroke="#c98720" stroke-width="2"/>
+  <text class="small" x="842" y="146" text-anchor="middle">revision 2</text>
+  <text class="heading" x="842" y="168" text-anchor="middle">active</text>
+  <text class="small" x="842" y="187" text-anchor="middle">Python 3.12</text>
 
-  <line x1="85" y1="125" x2="85" y2="330" stroke="#1a73e8" stroke-width="1.5"/>
+  <path class="line" d="M250 150H287"/>
+  <path class="line" d="M510 150H547"/>
 
-  <!-- Daily logs -->
-  <rect x="100" y="130" width="170" height="35" rx="4" fill="#34a853" opacity="0.15" stroke="#34a853" stroke-width="1"/>
-  <text x="115" y="152" font-size="12" fill="#202124" font-family="monospace">2026-07-08.jsonl</text>
+  <rect x="555" y="285" width="175" height="100" rx="12" fill="#fef3c7" stroke="#d09a13"/>
+  <text class="heading" x="642" y="317" text-anchor="middle">MEMORY.md</text>
+  <text class="body" x="642" y="343" text-anchor="middle">仅渲染 active 修订</text>
+  <text class="small" x="642" y="366" text-anchor="middle">可从 canonical state 重建</text>
 
-  <rect x="100" y="170" width="170" height="35" rx="4" fill="#f8f9fa" stroke="#34a853" stroke-width="1"/>
-  <text x="115" y="192" font-size="12" fill="#202124" font-family="monospace">2026-07-07.jsonl</text>
+  <rect x="785" y="285" width="140" height="100" rx="12" fill="#eee9ff" stroke="#7764c5"/>
+  <text class="heading" x="855" y="317" text-anchor="middle">Agent prompt</text>
+  <text class="body" x="855" y="343" text-anchor="middle">有界注入</text>
+  <text class="small" x="855" y="366" text-anchor="middle">不暴露未决候选</text>
 
-  <rect x="100" y="210" width="170" height="35" rx="4" fill="#f8f9fa" stroke="#34a853" stroke-width="1"/>
-  <text x="115" y="232" font-size="12" fill="#202124" font-family="monospace">2026-07-06.jsonl</text>
+  <path class="line" d="M842 225V250H642V277"/>
+  <path class="line" d="M730 335H777"/>
 
-  <text x="115" y="260" font-size="11" fill="#202124" font-style="italic">... 30 天内的日志 ...</text>
+  <rect x="35" y="285" width="475" height="100" rx="12" fill="#fff" stroke="#a9b2c1" stroke-dasharray="5 4"/>
+  <text class="heading" x="55" y="315">冲突或过期候选</text>
+  <text class="body" x="55" y="342">留在原始证据中，不修改 active 修订，也不进入 prompt</text>
+  <text class="small" x="55" y="366">DistillReport：conflicts / stale / skipped</text>
+  <path class="dash" d="M402 225V277"/>
 
-  <rect x="100" y="275" width="170" height="35" rx="4" fill="#f8f9fa" stroke="#34a853" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="115" y="297" font-size="12" fill="#999" font-family="monospace">2026-06-08.jsonl</text>
-
-  <text x="115" y="325" font-size="11" fill="#ea4335">超过30天 → 通过策略门槛，证据仍保留</text>
-
-  <!-- MEMORY.md -->
-  <rect x="480" y="55" width="280" height="200" rx="8" fill="#fbbc04" opacity="0.2" stroke="#fbbc04" stroke-width="2"/>
-  <rect x="480" y="55" width="280" height="35" rx="8" fill="#fbbc04"/>
-  <rect x="480" y="72" width="280" height="18" fill="#fbbc04"/>
-  <text x="620" y="77" text-anchor="middle" font-size="14" fill="#202124" font-weight="bold">MEMORY.md</text>
-
-  <text x="500" y="115" font-size="12" fill="#202124">策展的长期记忆</text>
-  <text x="500" y="135" font-size="11" fill="#202124">· 项目核心架构决策</text>
-  <text x="500" y="155" font-size="11" fill="#202124">· 关键技术选型及原因</text>
-  <text x="500" y="175" font-size="11" fill="#202124">· 重要约定与命名规范</text>
-  <text x="500" y="195" font-size="11" fill="#202124">· 已知陷阱与解决方案</text>
-  <text x="500" y="215" font-size="11" fill="#202124">· 跨会话的关键上下文</text>
-  <text x="500" y="240" font-size="11" fill="#fbbc04" font-weight="bold">精炼摘要, 非全量日志</text>
-
-  <!-- Distillation flow -->
-  <text x="330" y="128" text-anchor="middle" font-size="13" fill="#1a73e8" font-weight="bold">门槛通过</text>
-  <line x1="280" y1="140" x2="380" y2="160" stroke="#1a73e8" stroke-width="2" stroke-dasharray="5,3" marker-end="url(#arrowBlue)"/>
-
-  <rect x="360" y="165" width="80" height="35" rx="6" fill="#1a73e8"/>
-  <text x="400" y="187" text-anchor="middle" font-size="12" fill="white" font-weight="bold">蒸馏</text>
-
-  <line x1="440" y1="180" x2="475" y2="140" stroke="#1a73e8" stroke-width="2" marker-end="url(#arrowBlue)"/>
-
-  <!-- Append-only indicator -->
-  <rect x="450" y="300" width="310" height="90" rx="8" fill="#34a853" opacity="0.1" stroke="#34a853" stroke-width="1.5"/>
-  <text x="605" y="325" text-anchor="middle" font-size="13" fill="#34a853" font-weight="bold">日志文件特性</text>
-  <text x="470" y="345" font-size="11" fill="#202124">✓ append-only (只追加, 不修改)</text>
-  <text x="470" y="363" font-size="11" fill="#202124">✓ JSONL 每条事实带 evidence id</text>
-  <text x="470" y="381" font-size="11" fill="#202124">✓ scope 校验, 跨重启恢复</text>
-
-  <!-- Prompt injection -->
-  <rect x="50" y="375" width="350" height="95" rx="8" fill="#1a73e8" opacity="0.1" stroke="#1a73e8" stroke-width="1.5"/>
-  <text x="225" y="400" text-anchor="middle" font-size="13" fill="#1a73e8" font-weight="bold">Prompt 注入策略</text>
-  <text x="70" y="420" font-size="11" fill="#202124">每次会话自动加载:</text>
-  <text x="70" y="438" font-size="11" fill="#202124">· MEMORY.md (长期记忆)</text>
-  <text x="70" y="456" font-size="11" fill="#202124">· 今日日志 (当前上下文)</text>
-
-  <!-- Arrows from memory to prompt -->
-  <line x1="480" y1="255" x2="300" y2="375" stroke="#1a73e8" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowBlue)"/>
-  <polyline points="100,147 92,147 92,365 180,365 180,375" fill="none" stroke="#34a853" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <rect x="35" y="435" width="890" height="88" rx="12" fill="#edf2f7" stroke="#a9b2c1"/>
+  <text class="heading" x="55" y="465">不变量</text>
+  <text class="body" x="55" y="490">同一 memory_key 恰好一个 active 修订 · 修订号连续 · supersedes 链双向一致 · 原始 evidence 永不因蒸馏删除</text>
+  <text class="small" x="55" y="511">v1 状态按 legacy 语义读取，下一次成功蒸馏迁移为 v2；损坏状态显式报错。</text>
 </svg>

--- a/tests/test_workspace_memory.py
+++ b/tests/test_workspace_memory.py
@@ -48,6 +48,26 @@ def _old(day: int) -> datetime:
     return datetime(2026, 1, day, 12, tzinfo=timezone.utc)
 
 
+def _append_pair(
+    memory,
+    content: str,
+    *,
+    memory_key: str,
+    first_day: int,
+    prefix: str,
+    importance: int = 4,
+) -> None:
+    for offset in range(2):
+        memory.append_daily_log(
+            content,
+            kind="decision",
+            importance=importance,
+            memory_key=memory_key,
+            recorded_at=_old(first_day + offset),
+            fact_id=f"{prefix}{offset + 1}",
+        )
+
+
 def test_workspace_scope_isolated_and_log_is_append_only(s10, tmp_path: Path) -> None:
     first = s10.WorkspaceMemory(tmp_path / "project-a")
     second = s10.WorkspaceMemory(tmp_path / "project-b")
@@ -172,3 +192,308 @@ def test_reader_ignores_only_an_unterminated_corrupt_tail(s10, tmp_path: Path) -
     with memory.today_log_path().open("ab") as handle:
         handle.write(b'{"fact_id":')
     assert [fact.fact_id for fact in memory.read_daily_facts()] == ["valid"]
+
+
+def test_keyed_fact_validates_conflict_domain_and_writes_current_schema(
+    s10, tmp_path: Path
+) -> None:
+    memory = s10.WorkspaceMemory(tmp_path / "project")
+
+    fact = memory.append_daily_log(
+        "Use Python 3.12.",
+        kind="decision",
+        importance=5,
+        memory_key=" Runtime.Python-Version ",
+        recorded_at=_old(1),
+        fact_id="runtime1",
+    )
+
+    assert fact.memory_key == "runtime.python-version"
+    assert fact.schema_version == 2
+    stored = json.loads(
+        memory.daily_log_path(_old(1).date()).read_text(encoding="utf-8")
+    )
+    assert stored["memory_key"] == "runtime.python-version"
+    with pytest.raises(ValueError, match="memory_key"):
+        memory.append_daily_log(
+            "Invalid key.",
+            kind="decision",
+            memory_key="Runtime Python Version",
+        )
+
+    write_memory = next(
+        tool
+        for tool in s10.MemoryAwareAgent._build_tools()
+        if tool["name"] == "write_memory"
+    )
+    key_schema = write_memory["input_schema"]["properties"]["memory_key"]
+    assert key_schema["pattern"] == s10.MEMORY_KEY_PATTERN.pattern
+    assert "memory_key" not in write_memory["input_schema"]["required"]
+
+
+def test_confirmed_new_value_supersedes_without_deleting_old_evidence(
+    s10, tmp_path: Path
+) -> None:
+    memory = s10.WorkspaceMemory(tmp_path / "project")
+    memory.append_daily_log(
+        "Use Python 3.11.",
+        kind="decision",
+        importance=5,
+        memory_key="runtime.python-version",
+        recorded_at=_old(1),
+        fact_id="python-old",
+    )
+    as_of = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    first = memory.distill(as_of=as_of)
+    assert first.created == 1
+
+    memory.append_daily_log(
+        "Use Python 3.12.",
+        kind="decision",
+        importance=5,
+        memory_key="runtime.python-version",
+        recorded_at=_old(10),
+        fact_id="python-new-1",
+    )
+    unconfirmed = memory.distill(as_of=as_of)
+    assert unconfirmed.superseded == 0
+    assert "Use Python 3.11." in memory.read_memory_md()
+    assert "Use Python 3.12." not in memory.get_context_for_agent()
+
+    memory.append_daily_log(
+        "Use Python 3.12.",
+        kind="decision",
+        importance=4,
+        memory_key="runtime.python-version",
+        recorded_at=_old(11),
+        fact_id="python-new-2",
+    )
+    confirmed = memory.distill(as_of=as_of)
+    assert confirmed.created == 1
+    assert confirmed.superseded == 1
+    assert confirmed.conflicts == 0
+
+    payload = json.loads(memory.curated_file.read_text(encoding="utf-8"))
+    entries = sorted(payload["entries"], key=lambda entry: entry["revision"])
+    old, active = entries
+    assert payload["schema_version"] == 2
+    assert old["status"] == "superseded"
+    assert old["superseded_by"] == active["key"]
+    assert active["status"] == "active"
+    assert active["revision"] == 2
+    assert active["supersedes"] == old["key"]
+    assert active["evidence_ids"] == ["python-new-1", "python-new-2"]
+    assert len(memory.read_all_facts()) == 3
+
+    rendered = memory.read_memory_md()
+    assert "Use Python 3.12." in rendered
+    assert "Use Python 3.11." not in rendered
+    assert "Use Python 3.11." not in memory.get_context_for_agent()
+
+
+def test_stale_evidence_cannot_roll_back_active_revision(s10, tmp_path: Path) -> None:
+    memory = s10.WorkspaceMemory(tmp_path / "project")
+    memory.append_daily_log(
+        "Use Python 3.11.",
+        kind="decision",
+        importance=5,
+        memory_key="runtime.python-version",
+        recorded_at=_old(1),
+        fact_id="old-original",
+    )
+    as_of = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    memory.distill(as_of=as_of)
+    _append_pair(
+        memory,
+        "Use Python 3.12.",
+        memory_key="runtime.python-version",
+        first_day=10,
+        prefix="new",
+    )
+    memory.distill(as_of=as_of)
+
+    _append_pair(
+        memory,
+        "Use Python 3.11.",
+        memory_key="runtime.python-version",
+        first_day=5,
+        prefix="late-old",
+        importance=5,
+    )
+    report = memory.distill(as_of=as_of)
+
+    assert report.superseded == 0
+    assert report.stale == 2
+    entries = memory._load_curated()
+    assert len(entries) == 2
+    assert next(entry for entry in entries if entry.status == "active").content == (
+        "Use Python 3.12."
+    )
+
+
+def test_equal_strength_conflict_fails_closed_and_is_observable(
+    s10, tmp_path: Path
+) -> None:
+    memory = s10.WorkspaceMemory(tmp_path / "project")
+    memory.append_daily_log(
+        "Use SQLite.",
+        kind="decision",
+        importance=5,
+        memory_key="storage.database",
+        recorded_at=_old(1),
+        fact_id="database-current",
+    )
+    as_of = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    memory.distill(as_of=as_of)
+    for content, prefix in (("Use Postgres.", "pg"), ("Use MySQL.", "mysql")):
+        _append_pair(
+            memory,
+            content,
+            memory_key="storage.database",
+            first_day=10,
+            prefix=prefix,
+        )
+
+    report = memory.distill(as_of=as_of)
+
+    assert report.conflicts == 1
+    assert report.superseded == 0
+    assert report.created == 0
+    assert "Use SQLite." in memory.read_memory_md()
+    assert "Use Postgres." not in memory.get_context_for_agent()
+    assert "Use MySQL." not in memory.get_context_for_agent()
+    assert len(memory._load_curated()) == 1
+
+
+def test_supersession_is_idempotent_and_recovers_in_a_new_instance(
+    s10, tmp_path: Path
+) -> None:
+    root = tmp_path / "project"
+    writer = s10.WorkspaceMemory(root)
+    writer.append_daily_log(
+        "Use npm.",
+        kind="decision",
+        importance=5,
+        memory_key="frontend.package-manager",
+        recorded_at=_old(1),
+        fact_id="npm",
+    )
+    as_of = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    writer.distill(as_of=as_of)
+    _append_pair(
+        writer,
+        "Use pnpm.",
+        memory_key="frontend.package-manager",
+        first_day=10,
+        prefix="pnpm",
+    )
+    writer.distill(as_of=as_of)
+    before = writer.curated_file.read_text(encoding="utf-8")
+
+    rerun = writer.distill(as_of=as_of)
+    recovered = s10.WorkspaceMemory(root)
+    entries = recovered._load_curated()
+
+    assert rerun.created == 0
+    assert rerun.updated == 0
+    assert rerun.superseded == 0
+    assert writer.curated_file.read_text(encoding="utf-8") == before
+    assert len(entries) == 2
+    assert next(entry for entry in entries if entry.status == "active").revision == 2
+    assert "Use pnpm." in recovered.get_context_for_agent()
+    assert "Use npm." not in recovered.get_context_for_agent()
+
+
+def test_schema_one_curated_state_migrates_on_next_successful_distill(
+    s10, tmp_path: Path
+) -> None:
+    memory = s10.WorkspaceMemory(tmp_path / "project")
+    memory.curated_file.parent.mkdir(parents=True, exist_ok=True)
+    memory.curated_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "workspace_id": memory.workspace_id,
+                "entries": [
+                    {
+                        "key": "legacy-entry",
+                        "kind": "decision",
+                        "content": "Keep the legacy decision.",
+                        "first_seen": "2025-12-01T12:00:00Z",
+                        "last_seen": "2025-12-01T12:00:00Z",
+                        "evidence_ids": ["legacy-evidence"],
+                        "occurrences": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert "Keep the legacy decision." in memory.read_memory_md()
+    legacy = memory._load_curated()[0]
+    assert legacy.revision == 1
+    assert legacy.status == "active"
+    assert legacy.memory_key is None
+
+    memory.append_daily_log(
+        "Add a new convention.",
+        kind="convention",
+        importance=5,
+        recorded_at=_old(2),
+        fact_id="new-evidence",
+    )
+    memory.distill(as_of=datetime(2026, 3, 1, tzinfo=timezone.utc))
+    migrated = json.loads(memory.curated_file.read_text(encoding="utf-8"))
+
+    assert migrated["schema_version"] == 2
+    migrated_legacy = next(
+        entry for entry in migrated["entries"] if entry["key"] == "legacy-entry"
+    )
+    assert migrated_legacy["revision"] == 1
+    assert migrated_legacy["status"] == "active"
+    assert migrated_legacy["supersedes"] is None
+
+
+def test_corrupt_lifecycle_with_two_active_revisions_is_rejected(
+    s10, tmp_path: Path
+) -> None:
+    memory = s10.WorkspaceMemory(tmp_path / "project")
+    base = {
+        "kind": "decision",
+        "first_seen": "2026-01-01T12:00:00Z",
+        "last_seen": "2026-01-01T12:00:00Z",
+        "occurrences": 1,
+        "memory_key": "runtime.python-version",
+        "status": "active",
+        "supersedes": None,
+        "superseded_by": None,
+    }
+    memory.curated_file.parent.mkdir(parents=True, exist_ok=True)
+    memory.curated_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "workspace_id": memory.workspace_id,
+                "entries": [
+                    {
+                        **base,
+                        "key": "revision-one",
+                        "content": "Use Python 3.11.",
+                        "revision": 1,
+                        "evidence_ids": ["one"],
+                    },
+                    {
+                        **base,
+                        "key": "revision-two",
+                        "content": "Use Python 3.12.",
+                        "revision": 2,
+                        "evidence_ids": ["two"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(s10.MemoryCorruptionError, match="multiple active revisions"):
+        memory.read_memory_md()


### PR DESCRIPTION
## Summary

- add explicit `memory_key` conflict domains and v2-compatible lifecycle metadata
- require repeated, newer evidence before superseding active workspace memory
- fail closed on equal-strength conflicts and keep superseded revisions auditable
- inject only active keyed memory into agent context
- document the policy, migration behavior, and architecture with an updated diagram

## Verification

- `python -m pytest -q tests/test_workspace_memory.py` (13 passed)
- clean worktree: `python -m pytest -q tests/test_workspace_memory.py tests/test_project_structure.py` (27 passed)
- `python -m py_compile s10_workspace_memory/code.py tests/test_workspace_memory.py`
- `git diff --check`