### PR TITLE
feat(s11): add preference lifecycle and provenance

### DIFF
--- a/s11_user_memory/README.md
+++ b/s11_user_memory/README.md
@@ -2,7 +2,7 @@
 
 > 工作区记忆回答“这个项目长期有效的事实是什么”；用户记忆回答“这个人跨项目仍然有效的稳定信息与明确偏好是什么”。
 >
-> **Harness 层**：Memory ownership、显式状态变更与 Prompt context。
+> **Harness 层**：Memory ownership、显式状态变更、有效期、证据来源与 Prompt context。
 
 ---
 
@@ -35,9 +35,11 @@ s10 已经能把项目决策、约定和踩坑经验蒸馏成工作区记忆，�
 
 1. **Owner 是谁？** 每份状态都带稳定 `user_scope`，同一根目录可安全承载多个用户。
 2. **写入是否明确？** 只有 `update_user_profile` 和 `save_user_preference` 等显式工具能改变状态。
-3. **重复调用会怎样？** 相同 key/value 是 no-op，不增长文件、不增加 revision。
-4. **偏好变化会怎样？** 相同 key 的新 value 替换旧 value，Prompt 中不会同时出现冲突规则。
-5. **进程重启后信谁？** JSON 是 canonical state，Markdown 只是可读与 Prompt-facing projection，可从 JSON 修复。
+3. **重复调用会怎样？** value、source、expiry 和 source event 全部相同才是 no-op，不增长文件、不增加 revision。
+4. **偏好变化会怎样？** 相同 key 的新状态替换旧状态，旧时间戳不能回滚较新的 canonical evidence。
+5. **临时偏好何时失效？** `expires_at` 到达后记录仍可审计，但不再进入 `MEMORY.md` 或 Prompt。
+6. **偏好从哪里来？** Harness 可保存 s09 transcript event ID；该字段不开放给模型自行编造。
+7. **进程重启后信谁？** JSON 是 canonical state，Markdown 只是 active、Prompt-facing projection，可从 JSON 修复。
 
 ## 代码架构图
 
@@ -45,11 +47,14 @@ s10 已经能把项目决策、约定和踩坑经验蒸馏成工作区记忆，�
 flowchart LR
     U["Explicit user request"] --> T{"Memory tool"}
     T -->|"profile patch"| P["profile.json"]
-    T -->|"key + value"| D["Preference deduper"]
+    T -->|"key + value + expiry"| D["Preference lifecycle gate"]
+    E["s09 event ID"] -->|"Harness attaches"| D
     D -->|"create / update"| J["preferences.json"]
-    D -->|"same key + value"| N["UNCHANGED / no disk write"]
+    D -->|"same complete state"| N["UNCHANGED / no disk write"]
+    J --> G{"active at as_of?"}
+    G -->|"yes"| MP["MEMORY.md"]
+    G -->|"expired"| H["canonical audit only"]
     P --> UP["persona/user.md"]
-    J --> MP["MEMORY.md"]
     UP --> C["User context block"]
     MP --> C
     C --> A["Agent prompt assembly"]
@@ -85,7 +90,7 @@ flowchart LR
 | 文件 | 角色 | 是否作为真相来源 |
 |---|---|---|
 | `profile.json` | 结构化用户资料 | 是 |
-| `preferences.json` | 带 key、revision、source 的偏好集合 | 是 |
+| `preferences.json` | 带 key、revision、expiry、source event 的完整偏好集合 | 是，包括已过期记录 |
 | `persona/user.md` | 便于人阅读的 Profile 投影 | 否，可重建 |
 | `MEMORY.md` | 便于检查和注入 Prompt 的 Preference 投影 | 否，可重建 |
 | `persona/core.md` | 助手价值与边界 | 独立的 assistant identity |
@@ -134,7 +139,28 @@ UPDATED   revision=2  previous=Chinese  current=English
 
 去重不能只比较整段文本。例如“回复使用中文”和“以后回复使用英文”不是两条并存的长期事实，而是同一个 `response.language` 偏好的两个版本。稳定 key 提供冲突域，value 表示当前状态。
 
-### 3. 显式删除
+完整幂等身份还包含 `source`、`expires_at` 和 `source_event_id`。相同 value 但延长期限或补充新的来源证据属于可观察更新，会增加 revision；仅 `updated_at` 不同的完整重试仍然是 `UNCHANGED`。不同状态的写入时间必须晚于 canonical `updated_at`，避免重放旧 transcript 时回滚新偏好。
+
+### 3. 临时偏好与 active projection
+
+```python
+memory.set_preference(
+    "response.detail",
+    "verbose during onboarding",
+    source="transcript",
+    source_event_id="session-7:event-42",
+    updated_at="2026-08-01T01:00:00Z",
+    expires_at="2026-08-02T01:00:00Z",
+)
+```
+
+时间戳必须包含时区并统一保存为 UTC。偏好在 `as_of < expires_at` 时 active；到达 `expires_at` 的瞬间即 expired。`list_preferences()` 返回全部 canonical records，`list_active_preferences(as_of=...)` 才返回可注入集合。
+
+过期不是删除：记录继续留在 `preferences.json`，以便解释它曾经为何生效；`MEMORY.md` 和 `get_context_for_agent()` 只投影 active records。显式历史 `as_of` 查询是纯读取，不会把历史视图写回当前 `MEMORY.md`。
+
+`source_event_id` 是 Harness provenance，不是模型生成内容。程序化调用方可以把 s09 的稳定 event ID 附在写入上；`save_user_preference` 模型工具只接受 value 和可选 expiry，不能提交或伪造 event ID。
+
+### 4. 显式删除
 
 ```python
 memory.delete_preference("response.language")
@@ -142,7 +168,7 @@ memory.delete_preference("response.language")
 
 删除按 key 精确执行，不对自然语言做模糊匹配。Harness 因此可以向用户展示将删除的具体偏好，也能在审计日志中记录明确目标。
 
-### 4. 多用户隔离
+### 5. 多用户隔离
 
 ```python
 alice = UserMemory(root, user_id="alice")
@@ -154,7 +180,7 @@ bob.set_preference("editor.indent", "spaces")
 
 两者共享状态根目录，但落入不同 `scope-id`。读取时还会校验 JSON 内部的 `user_scope`：路径隔离负责正常路由，scope marker 负责发现错误复制或调用方传错用户。
 
-### 5. Prompt context
+### 6. Prompt context
 
 ```text
 ## Assistant values
@@ -203,7 +229,9 @@ validate -> serialize -> write temp file -> fsync -> os.replace
 
 如果写临时文件时进程失败，旧 canonical file 仍然存在；成功替换后，不会留下“写了一半的 JSON”。新进程重新创建 `UserMemory(root, user_id=...)` 即可恢复状态，不依赖内存缓存。
 
-`MEMORY.md` 被人工改坏或处于旧版本时，`read_memory()` 会根据 `preferences.json` 重新生成投影。这体现了 Harness 中常见的原则：可读视图可以修复，canonical state 必须有清晰边界。
+`MEMORY.md` 被人工改坏、过期或处于旧版本时，`read_memory()` 会根据 canonical records 和当前时间重新生成 active projection。这体现了 Harness 中常见的原则：可读视图可以修复，canonical state 必须有清晰边界。
+
+当前 schema 为 v2，读取器仍接受 v1 profile 与 preferences。v1 Preference 缺少的 `expires_at` 和 `source_event_id` 按 `None` 恢复，下一次发生可观察写入时统一保存为 v2；读取本身不会为了迁移而修改 canonical state。
 
 ## 离线验证
 
@@ -211,6 +239,10 @@ validate -> serialize -> write temp file -> fsync -> os.replace
 
 - Profile partial update、删除和跨重启读取；
 - Preference create/update/unchanged revision 语义；
+- expiry 的时区校验、到期边界和 active/expired 投影；
+- source event provenance、跨重启恢复与模型不可伪造边界；
+- stale timestamp 防回滚与 lifecycle/provenance revision；
+- schema v1 兼容读取和下一次可观察更新迁移；
 - 同 key 只保留当前值；
 - 两个用户共享 root 时仍然隔离；
 - 错误复制的跨 scope JSON 被拒绝；
@@ -248,8 +280,8 @@ python s11_user_memory/code.py
 
 ## 练习
 
-1. 给 `set_preference` 增加可选的 `expires_at`，让临时跨项目偏好自动失效。
-2. 在不改变存储所有权的前提下，为 Preference 增加来源事件 ID，连接 s09 transcript 证据。
+1. 把单个 `source_event_id` 扩展为有界 evidence set，同时保持同一证据重试幂等。
+2. 为即将过期的偏好增加显式续期确认流程，比较“自动续期”和“用户确认”的权限边界。
 3. 在 s15 Prompt assembly 中实现明确的优先级：本轮用户指令 > workspace override > user default。
 
 ## 下一课

--- a/s11_user_memory/code.py
+++ b/s11_user_memory/code.py
@@ -42,6 +42,8 @@ PROGRESSION = {
         "user-scoped profile",
         "explicit preference updates",
         "idempotent preference dedupe",
+        "expiring preference lifecycle",
+        "source-event provenance",
     ],
     "preserves": ["workspace memory remains a separate ownership layer"],
 }
@@ -81,12 +83,15 @@ if os.getenv("ANTHROPIC_BASE_URL"):
 WORKDIR = Path.cwd()
 # The tutorial namespace cannot collide with a real product's ~/.workbuddy.
 USER_MEMORY_ROOT = tutorial_workbuddy_home() / "user-memory"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+SUPPORTED_SCHEMA_VERSIONS = frozenset({1, SCHEMA_VERSION})
 MAX_PREFERENCE_CHARS = 4_000
+MAX_SOURCE_EVENT_ID_CHARS = 200
 PROFILE_FIELDS = frozenset(
     {"name", "call_them", "pronouns", "city", "timezone", "notes"}
 )
 PREFERENCE_KEY = re.compile(r"^[a-z0-9]+(?:[._-][a-z0-9]+)*$")
+SOURCE_EVENT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,199}$")
 
 
 BOOTSTRAP_TEMPLATE = """# Bootstrap
@@ -134,6 +139,10 @@ class UserMemoryValidationError(UserMemoryError):
     """Raised before invalid profile or preference data reaches disk."""
 
 
+class StalePreferenceUpdateError(UserMemoryError):
+    """Raised when older evidence attempts to replace a newer preference."""
+
+
 class WriteStatus(str, Enum):
     """Observable result of an explicit preference mutation."""
 
@@ -141,6 +150,13 @@ class WriteStatus(str, Enum):
     UPDATED = "updated"
     UNCHANGED = "unchanged"
     DELETED = "deleted"
+
+
+class PreferenceStatus(str, Enum):
+    """Time-derived state; expiration never deletes canonical evidence."""
+
+    ACTIVE = "active"
+    EXPIRED = "expired"
 
 
 @dataclass(frozen=True)
@@ -152,16 +168,59 @@ class Preference:
     source: str
     updated_at: str
     revision: int = 1
+    expires_at: str | None = None
+    source_event_id: str | None = None
+
+    def status(self, *, as_of: datetime | None = None) -> PreferenceStatus:
+        if self.expires_at is None:
+            return PreferenceStatus.ACTIVE
+        return (
+            PreferenceStatus.ACTIVE
+            if _as_utc(as_of)
+            < _parse_timestamp(self.expires_at, field_name="expires_at")
+            else PreferenceStatus.EXPIRED
+        )
+
+    def is_active(self, *, as_of: datetime | None = None) -> bool:
+        return self.status(as_of=as_of) is PreferenceStatus.ACTIVE
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, object]) -> "Preference":
         try:
+            revision = int(payload.get("revision", 1))
+            if revision < 1:
+                raise ValueError("revision must be positive")
+            updated_at = _normalize_timestamp(
+                str(payload["updated_at"]), field_name="updated_at"
+            )
+            raw_expiry = payload.get("expires_at")
+            expires_at = (
+                None
+                if raw_expiry in (None, "")
+                else _normalize_timestamp(str(raw_expiry), field_name="expires_at")
+            )
+            if expires_at is not None and _parse_timestamp(
+                expires_at, field_name="expires_at"
+            ) <= _parse_timestamp(updated_at, field_name="updated_at"):
+                raise ValueError("expires_at must be later than updated_at")
             return cls(
-                key=str(payload["key"]),
-                value=str(payload["value"]),
-                source=str(payload.get("source", "explicit")),
-                updated_at=str(payload["updated_at"]),
-                revision=int(payload.get("revision", 1)),
+                key=_preference_key(str(payload["key"])),
+                value=_clean_text(
+                    payload["value"],
+                    field_name="preference value",
+                    max_chars=MAX_PREFERENCE_CHARS,
+                ),
+                source=_clean_text(
+                    payload.get("source", "explicit"),
+                    field_name="source",
+                    max_chars=100,
+                ),
+                updated_at=updated_at,
+                revision=revision,
+                expires_at=expires_at,
+                source_event_id=_optional_source_event_id(
+                    payload.get("source_event_id")
+                ),
             )
         except (KeyError, TypeError, ValueError) as exc:
             raise UserMemoryValidationError(f"invalid preference record: {exc}") from exc
@@ -186,8 +245,35 @@ class ProfileWrite:
     unchanged: tuple[str, ...] = field(default_factory=tuple)
 
 
+def _as_utc(value: datetime | None = None) -> datetime:
+    current = value or datetime.now(timezone.utc)
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise UserMemoryValidationError("as_of must include a timezone")
+    return current.astimezone(timezone.utc)
+
+
+def _format_timestamp(value: datetime) -> str:
+    return _as_utc(value).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str, *, field_name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise UserMemoryValidationError(
+            f"{field_name} must be an ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise UserMemoryValidationError(f"{field_name} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_timestamp(value: str, *, field_name: str) -> str:
+    return _format_timestamp(_parse_timestamp(value, field_name=field_name))
+
+
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return _format_timestamp(datetime.now(timezone.utc))
 
 
 def _scope_id(user_id: str) -> str:
@@ -217,6 +303,21 @@ def _clean_text(value: object, *, field_name: str, max_chars: int) -> str:
             f"{field_name} exceeds the {max_chars}-character teaching limit"
         )
     return text
+
+
+def _optional_source_event_id(value: object | None) -> str | None:
+    if value is None:
+        return None
+    event_id = _clean_text(
+        value,
+        field_name="source_event_id",
+        max_chars=MAX_SOURCE_EVENT_ID_CHARS,
+    )
+    if not SOURCE_EVENT_ID.fullmatch(event_id):
+        raise UserMemoryValidationError(
+            "source_event_id must be an opaque event identifier"
+        )
+    return event_id
 
 
 class UserMemory:
@@ -328,6 +429,8 @@ class UserMemory:
     # ── Preferences: addressable, explicit cross-project rules ─
 
     def list_preferences(self) -> list[Preference]:
+        """Return every canonical record, including expired audit evidence."""
+
         payload = self._read_scoped_json(
             self.preferences_path, default_key="preferences"
         )
@@ -339,6 +442,18 @@ class UserMemory:
             raise UserMemoryValidationError("duplicate preference keys in canonical state")
         return sorted(preferences, key=lambda item: item.key)
 
+    def list_active_preferences(
+        self, *, as_of: datetime | None = None
+    ) -> list[Preference]:
+        """Return the time-bounded projection eligible for prompt injection."""
+
+        current = _as_utc(as_of)
+        return [
+            preference
+            for preference in self.list_preferences()
+            if preference.is_active(as_of=current)
+        ]
+
     def set_preference(
         self,
         key: str,
@@ -346,12 +461,14 @@ class UserMemory:
         *,
         source: str = "explicit",
         updated_at: str | None = None,
+        expires_at: str | None = None,
+        source_event_id: str | None = None,
     ) -> PreferenceWrite:
         """Create or replace one preference using its stable semantic key.
 
-        Repeating the same key/value pair is a true no-op: no revision bump and
-        no disk rewrite.  A different value is an update, not a second line in
-        MEMORY.md, so stale and current rules cannot both reach the prompt.
+        A retry is a true no-op only when value, source, expiry, and source event
+        all match. Changing lifecycle or provenance is an observable revision,
+        even when the user-facing value stays the same.
         """
 
         normalized_key = _preference_key(key)
@@ -359,10 +476,33 @@ class UserMemory:
             value, field_name="preference value", max_chars=MAX_PREFERENCE_CHARS
         )
         normalized_source = _clean_text(source, field_name="source", max_chars=100)
+        normalized_updated_at = _normalize_timestamp(
+            updated_at or _now_iso(), field_name="updated_at"
+        )
+        normalized_expires_at = (
+            None
+            if expires_at is None
+            else _normalize_timestamp(expires_at, field_name="expires_at")
+        )
+        if normalized_expires_at is not None and _parse_timestamp(
+            normalized_expires_at, field_name="expires_at"
+        ) <= _parse_timestamp(normalized_updated_at, field_name="updated_at"):
+            raise UserMemoryValidationError("expires_at must be later than updated_at")
+        normalized_source_event_id = _optional_source_event_id(source_event_id)
         preferences = {item.key: item for item in self.list_preferences()}
         previous = preferences.get(normalized_key)
 
-        if previous and previous.value == normalized_value:
+        if previous and (
+            previous.value,
+            previous.source,
+            previous.expires_at,
+            previous.source_event_id,
+        ) == (
+            normalized_value,
+            normalized_source,
+            normalized_expires_at,
+            normalized_source_event_id,
+        ):
             return PreferenceWrite(
                 WriteStatus.UNCHANGED,
                 normalized_key,
@@ -371,13 +511,22 @@ class UserMemory:
                 previous.revision,
             )
 
+        if previous and _parse_timestamp(
+            normalized_updated_at, field_name="updated_at"
+        ) <= _parse_timestamp(previous.updated_at, field_name="updated_at"):
+            raise StalePreferenceUpdateError(
+                f"preference {normalized_key} has newer canonical evidence"
+            )
+
         revision = previous.revision + 1 if previous else 1
         preferences[normalized_key] = Preference(
             key=normalized_key,
             value=normalized_value,
             source=normalized_source,
-            updated_at=updated_at or _now_iso(),
+            updated_at=normalized_updated_at,
             revision=revision,
+            expires_at=normalized_expires_at,
+            source_event_id=normalized_source_event_id,
         )
         self._store_preferences(preferences.values())
         return PreferenceWrite(
@@ -407,11 +556,15 @@ class UserMemory:
             previous.revision,
         )
 
-    def read_memory(self) -> str:
-        """Return the derived preference view, repairing stale projections."""
+    def read_memory(self, *, as_of: datetime | None = None) -> str:
+        """Return active preferences without deleting expired canonical state.
 
-        expected = self._render_preferences(self.list_preferences())
-        if self._read_text(self.memory_path) != expected:
+        Historical ``as_of`` reads are pure: they never replace the current
+        MEMORY.md projection with a time-travel view.
+        """
+
+        expected = self._render_preferences(self.list_active_preferences(as_of=as_of))
+        if as_of is None and self._read_text(self.memory_path) != expected:
             self._atomic_write_text(self.memory_path, expected)
         return expected
 
@@ -446,7 +599,7 @@ class UserMemory:
         )
         self.update_profile(profile)
 
-    def load_identity(self) -> dict[str, str]:
+    def load_identity(self, *, as_of: datetime | None = None) -> dict[str, str]:
         """Load readable prompt blocks without exposing canonical JSON."""
 
         profile = self.read_profile()
@@ -456,18 +609,18 @@ class UserMemory:
             "soul": self._read_text(self.soul_path),
             "identity": self._read_text(self.identity_path),
             "user": self._read_text(self.user_path),
-            "memory": self.read_memory(),
+            "memory": self.read_memory(as_of=as_of),
         }
 
     def is_identity_established(self) -> bool:
         return bool(self.read_profile()) and self.soul_path.exists() and self.identity_path.exists()
 
-    def get_context_for_agent(self) -> str:
+    def get_context_for_agent(self, *, as_of: datetime | None = None) -> str:
         """Build only user-owned prompt blocks; workspace context is a caller concern."""
 
         if not self.is_identity_established():
             return "(user identity not yet established)"
-        identity = self.load_identity()
+        identity = self.load_identity(as_of=as_of)
         parts = [
             f"## Assistant values\n{identity['soul'].strip()}",
             f"## Assistant identity\n{identity['identity'].strip()}",
@@ -497,6 +650,16 @@ class UserMemory:
             raise UserMemoryValidationError(f"{path.name} root must be a JSON object")
         if payload.get("user_scope") != self.scope_id:
             raise UserScopeError(f"{path.name} belongs to another user scope")
+        try:
+            schema_version = int(payload.get("schema_version", 1))
+        except (TypeError, ValueError) as exc:
+            raise UserMemoryValidationError(
+                f"{path.name} has an invalid schema version"
+            ) from exc
+        if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+            raise UserMemoryValidationError(
+                f"{path.name} uses unsupported schema {schema_version}"
+            )
         return payload
 
     def _write_scoped_json(
@@ -518,7 +681,8 @@ class UserMemory:
             "preferences",
             [asdict(item) for item in ordered],
         )
-        self._atomic_write_text(self.memory_path, self._render_preferences(ordered))
+        active = [item for item in ordered if item.is_active()]
+        self._atomic_write_text(self.memory_path, self._render_preferences(active))
 
     def _write_profile_projection(self, profile: Mapping[str, str]) -> None:
         labels = {
@@ -540,7 +704,9 @@ class UserMemory:
         if not preferences:
             return ""
         lines = ["# Explicit User Preferences", ""]
-        lines.extend(f"- `{item.key}`: {item.value}" for item in preferences)
+        for item in preferences:
+            expiry = f" (expires {item.expires_at})" if item.expires_at else ""
+            lines.append(f"- `{item.key}`: {item.value}{expiry}")
         return "\n".join(lines) + "\n"
 
     @staticmethod
@@ -705,7 +871,9 @@ class IdentityAwareAgent:
 {self.memory.get_context_for_agent()}
 
 Only persist a profile or preference when the user explicitly asks. User memory
-is cross-project; project decisions belong to workspace memory instead."""
+is cross-project; project decisions belong to workspace memory instead. Use
+expires_at for explicitly temporary preferences. Provenance IDs are attached by
+the harness and must never be invented from conversation text."""
 
     @staticmethod
     def _build_tools() -> list[dict]:
@@ -737,6 +905,14 @@ is cross-project; project decisions belong to workspace memory instead."""
                     "properties": {
                         "key": {"type": "string"},
                         "value": {"type": "string"},
+                        "expires_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": (
+                                "Optional timezone-aware expiry for a temporary "
+                                "cross-project preference"
+                            ),
+                        },
                     },
                     "required": ["key", "value"],
                 },
@@ -779,7 +955,14 @@ is cross-project; project decisions belong to workspace memory instead."""
             return json.dumps(asdict(result), ensure_ascii=False)
         if name == "save_user_preference":
             result = self.memory.set_preference(
-                str(arguments.get("key", "")), str(arguments.get("value", ""))
+                str(arguments.get("key", "")),
+                str(arguments.get("value", "")),
+                source="model_tool",
+                expires_at=(
+                    None
+                    if arguments.get("expires_at") in (None, "")
+                    else str(arguments["expires_at"])
+                ),
             )
             return json.dumps(asdict(result), ensure_ascii=False, default=str)
         return f"Error: unknown tool {name}"

--- a/s11_user_memory/images/user-memory.svg
+++ b/s11_user_memory/images/user-memory.svg
@@ -12,13 +12,13 @@
   </defs>
 
   <rect width="900" height="600" fill="#f8fafc"/>
-  <text x="450" y="38" text-anchor="middle" font-size="23" font-weight="700" fill="#0f172a">User Memory：明确的用户所有权</text>
-  <text x="450" y="61" text-anchor="middle" font-size="12" fill="#64748b">Profile 与 Preference 分开建模；Workspace Memory 不进入此存储边界</text>
+  <text x="450" y="38" text-anchor="middle" font-size="23" font-weight="700" fill="#0f172a">User Memory：所有权、有效期与证据</text>
+  <text x="450" y="61" text-anchor="middle" font-size="12" fill="#64748b">Canonical records 保留历史；只有 active Preference 进入 Prompt</text>
 
   <!-- An explicit user request is the only write trigger. -->
   <rect x="34" y="100" width="174" height="72" rx="10" fill="#ffffff" stroke="#94a3b8" filter="url(#shadow)"/>
   <text x="121" y="128" text-anchor="middle" font-size="14" font-weight="700" fill="#0f172a">Explicit request</text>
-  <text x="121" y="150" text-anchor="middle" font-size="12" fill="#475569">明确保存 / 更新 / 删除</text>
+  <text x="121" y="150" text-anchor="middle" font-size="12" fill="#475569">明确保存 / 限时 / 更新 / 删除</text>
 
   <line x1="208" y1="136" x2="261" y2="136" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
 
@@ -26,7 +26,7 @@
   <rect x="270" y="90" width="218" height="92" rx="10" fill="#dbeafe" stroke="#2563eb" stroke-width="2" filter="url(#shadow)"/>
   <text x="379" y="120" text-anchor="middle" font-size="15" font-weight="700" fill="#1e3a8a">Memory tool boundary</text>
   <text x="379" y="145" text-anchor="middle" font-size="12" fill="#1e40af">update_user_profile</text>
-  <text x="379" y="164" text-anchor="middle" font-size="12" fill="#1e40af">save / delete_user_preference</text>
+  <text x="379" y="164" text-anchor="middle" font-size="12" fill="#1e40af">save preference + optional expiry</text>
 
   <!-- Stable user scope routes all reads and writes. -->
   <line x1="488" y1="136" x2="542" y2="136" stroke="#2563eb" stroke-width="2" marker-end="url(#arrowBlue)"/>
@@ -37,6 +37,7 @@
   <!-- Two canonical stores have different mutation semantics. -->
   <line x1="645" y1="172" x2="506" y2="226" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
   <line x1="770" y1="172" x2="782" y2="226" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="744" y="210" text-anchor="middle" font-size="10" fill="#64748b">Harness attaches s09 event ID</text>
 
   <rect x="315" y="235" width="270" height="105" rx="10" fill="#ecfdf5" stroke="#10b981" stroke-width="2" filter="url(#shadow)"/>
   <text x="450" y="264" text-anchor="middle" font-size="15" font-weight="700" fill="#065f46">profile.json</text>
@@ -46,9 +47,9 @@
 
   <rect x="610" y="235" width="256" height="105" rx="10" fill="#fff7ed" stroke="#f97316" stroke-width="2" filter="url(#shadow)"/>
   <text x="738" y="264" text-anchor="middle" font-size="15" font-weight="700" fill="#9a3412">preferences.json</text>
-  <text x="738" y="288" text-anchor="middle" font-size="12" fill="#c2410c">keyed current rules</text>
-  <text x="738" y="309" text-anchor="middle" font-size="12" fill="#c2410c">CREATED · UPDATED · UNCHANGED</text>
-  <text x="738" y="328" text-anchor="middle" font-size="11" fill="#64748b">key · value · revision · source</text>
+  <text x="738" y="288" text-anchor="middle" font-size="12" fill="#c2410c">keyed canonical records</text>
+  <text x="738" y="309" text-anchor="middle" font-size="12" fill="#c2410c">active / expired · stale update reject</text>
+  <text x="738" y="328" text-anchor="middle" font-size="11" fill="#64748b">revision · expires_at · source_event_id</text>
 
   <!-- Canonical JSON drives human/prompt-facing projections. -->
   <line x1="450" y1="340" x2="450" y2="388" stroke="#10b981" stroke-width="2" marker-end="url(#arrow)"/>
@@ -60,7 +61,7 @@
 
   <rect x="610" y="396" width="256" height="62" rx="9" fill="#ffffff" stroke="#f97316"/>
   <text x="738" y="422" text-anchor="middle" font-size="14" font-weight="700" fill="#9a3412">MEMORY.md</text>
-  <text x="738" y="443" text-anchor="middle" font-size="11" fill="#64748b">当前 Preference projection · 可重建</text>
+  <text x="738" y="443" text-anchor="middle" font-size="11" fill="#64748b">active-only projection · 可重建</text>
 
   <line x1="450" y1="458" x2="524" y2="500" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
   <line x1="738" y1="458" x2="652" y2="500" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
@@ -77,5 +78,5 @@
   <line x1="274" y1="299" x2="286" y2="323" stroke="#b91c1c" stroke-width="2"/>
   <line x1="286" y1="299" x2="274" y2="323" stroke="#b91c1c" stroke-width="2"/>
 
-  <text x="34" y="580" font-size="11" fill="#64748b">s15 可在 Prompt assembly 时组合 user context 与 workspace context，但不会合并两层 canonical state。</text>
+  <text x="34" y="580" font-size="11" fill="#64748b">过期记录留在 JSON 审计；s15 可组合 active user context 与 workspace context，但不合并 canonical state。</text>
 </svg>

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -160,3 +161,176 @@ def test_preference_json_is_stable_and_addressable(s11, tmp_path: Path) -> None:
         "editor.indent",
         "response.detail",
     ]
+
+
+def test_expired_preference_stays_canonical_but_never_reaches_prompt(
+    s11, tmp_path: Path
+) -> None:
+    memory = s11.UserMemory(tmp_path / "user-memory", user_id="alice")
+    _establish_identity(memory)
+    memory.set_preference(
+        "response.detail",
+        "verbose during onboarding",
+        source="transcript",
+        source_event_id="session-7:event-42",
+        updated_at="2026-08-01T09:00:00+08:00",
+        expires_at="2026-08-02T09:00:00+08:00",
+    )
+    before_expiry = datetime(2026, 8, 2, 0, 59, 59, tzinfo=timezone.utc)
+    at_expiry = datetime(2026, 8, 2, 1, 0, 0, tzinfo=timezone.utc)
+
+    preference = memory.list_preferences()[0]
+    assert preference.updated_at == "2026-08-01T01:00:00Z"
+    assert preference.expires_at == "2026-08-02T01:00:00Z"
+    assert preference.source_event_id == "session-7:event-42"
+    assert preference.status(as_of=before_expiry) is s11.PreferenceStatus.ACTIVE
+    assert preference.status(as_of=at_expiry) is s11.PreferenceStatus.EXPIRED
+    assert "response.detail" in memory.get_context_for_agent(as_of=before_expiry)
+    assert "response.detail" not in memory.get_context_for_agent(as_of=at_expiry)
+
+    # Time-travel reads are pure and expired records remain auditable.
+    current_projection = memory.memory_path.read_text(encoding="utf-8")
+    assert "response.detail" in memory.read_memory(as_of=before_expiry)
+    assert memory.memory_path.read_text(encoding="utf-8") == current_projection
+    payload = json.loads(memory.preferences_path.read_text(encoding="utf-8"))
+    assert len(payload["preferences"]) == 1
+
+
+def test_lifecycle_and_provenance_changes_are_revisioned_but_retries_are_not(
+    s11, tmp_path: Path
+) -> None:
+    memory = s11.UserMemory(tmp_path / "user-memory", user_id="alice")
+    common = {
+        "source": "transcript",
+        "source_event_id": "event-1",
+        "expires_at": "2099-01-01T00:00:00Z",
+    }
+    created = memory.set_preference(
+        "response.language",
+        "Chinese",
+        updated_at="2026-08-01T00:00:00Z",
+        **common,
+    )
+    retry = memory.set_preference(
+        "response.language",
+        "Chinese",
+        updated_at="2026-08-02T00:00:00Z",
+        **common,
+    )
+    extended = memory.set_preference(
+        "response.language",
+        "Chinese",
+        source="transcript",
+        source_event_id="event-1",
+        updated_at="2026-08-03T00:00:00Z",
+        expires_at="2099-02-01T00:00:00Z",
+    )
+    new_evidence = memory.set_preference(
+        "response.language",
+        "Chinese",
+        source="transcript",
+        source_event_id="event-2",
+        updated_at="2026-08-04T00:00:00Z",
+        expires_at="2099-02-01T00:00:00Z",
+    )
+
+    assert created.status is s11.WriteStatus.CREATED
+    assert retry.status is s11.WriteStatus.UNCHANGED
+    assert retry.revision == 1
+    assert extended.status is s11.WriteStatus.UPDATED
+    assert extended.revision == 2
+    assert new_evidence.status is s11.WriteStatus.UPDATED
+    assert new_evidence.revision == 3
+    recovered = s11.UserMemory(tmp_path / "user-memory", user_id="alice")
+    assert recovered.list_preferences()[0].source_event_id == "event-2"
+
+    with pytest.raises(s11.StalePreferenceUpdateError, match="newer canonical"):
+        recovered.set_preference(
+            "response.language",
+            "English",
+            source="transcript",
+            source_event_id="stale-event",
+            updated_at="2026-08-03T12:00:00Z",
+        )
+    assert recovered.list_preferences()[0].value == "Chinese"
+
+
+def test_timestamps_and_source_event_ids_fail_closed(s11, tmp_path: Path) -> None:
+    memory = s11.UserMemory(tmp_path / "user-memory", user_id="alice")
+
+    with pytest.raises(s11.UserMemoryValidationError, match="timezone"):
+        memory.set_preference(
+            "response.detail",
+            "concise",
+            updated_at="2026-08-01T00:00:00",
+        )
+    with pytest.raises(s11.UserMemoryValidationError, match="later than"):
+        memory.set_preference(
+            "response.detail",
+            "concise",
+            updated_at="2026-08-02T00:00:00Z",
+            expires_at="2026-08-02T00:00:00Z",
+        )
+    with pytest.raises(s11.UserMemoryValidationError, match="source_event_id"):
+        memory.set_preference(
+            "response.detail",
+            "concise",
+            source_event_id="event id with spaces",
+        )
+    with pytest.raises(s11.UserMemoryValidationError, match="as_of"):
+        memory.list_active_preferences(as_of=datetime(2026, 8, 1))
+
+
+def test_schema_one_preferences_migrate_on_next_observable_update(
+    s11, tmp_path: Path
+) -> None:
+    memory = s11.UserMemory(tmp_path / "user-memory", user_id="alice")
+    memory.preferences_path.parent.mkdir(parents=True, exist_ok=True)
+    memory.preferences_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "user_scope": memory.scope_id,
+                "preferences": [
+                    {
+                        "key": "response.language",
+                        "value": "Chinese",
+                        "source": "explicit",
+                        "updated_at": "2026-08-01T00:00:00Z",
+                        "revision": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    legacy = memory.list_preferences()[0]
+    assert legacy.expires_at is None
+    assert legacy.source_event_id is None
+    memory.set_preference(
+        "response.language",
+        "Chinese",
+        updated_at="2026-08-02T00:00:00Z",
+        expires_at="2099-01-01T00:00:00Z",
+        source_event_id="event-migration",
+    )
+    migrated = json.loads(memory.preferences_path.read_text(encoding="utf-8"))
+
+    assert migrated["schema_version"] == 2
+    record = migrated["preferences"][0]
+    assert record["revision"] == 2
+    assert record["expires_at"] == "2099-01-01T00:00:00Z"
+    assert record["source_event_id"] == "event-migration"
+
+
+def test_model_tool_can_set_expiry_but_cannot_forge_source_event_id(s11) -> None:
+    tool = next(
+        item
+        for item in s11.IdentityAwareAgent._build_tools()
+        if item["name"] == "save_user_preference"
+    )
+    properties = tool["input_schema"]["properties"]
+
+    assert properties["expires_at"]["format"] == "date-time"
+    assert "source_event_id" not in properties


### PR DESCRIPTION
## Summary

- upgrade S11 user-memory state to a backward-compatible v2 schema
- add timezone-aware preference expiry while retaining expired canonical audit records
- attach optional transcript event provenance without exposing provenance IDs to the model tool
- reject stale updates and revision lifecycle or provenance changes deterministically
- project only active preferences into `MEMORY.md` and agent context
- document lifecycle boundaries and update the S11 architecture diagram

## Verification

- `python -m pytest -q tests/test_user_memory.py tests/test_chapter_security_parity.py tests/test_chapter_imports.py` (20 passed)
- clean worktree: `python -m pytest -q tests/test_user_memory.py tests/test_chapter_security_parity.py tests/test_chapter_imports.py tests/test_project_structure.py` (34 passed)
- `python -m py_compile s11_user_memory/code.py tests/test_user_memory.py`
- `git diff --check`