### PR TITLE
feat(s15): add explicit preference precedence

### DIFF
--- a/s11_user_memory/README.md
+++ b/s11_user_memory/README.md
@@ -282,7 +282,7 @@ python s11_user_memory/code.py
 
 1. 把单个 `source_event_id` 扩展为有界 evidence set，同时保持同一证据重试幂等。
 2. 为即将过期的偏好增加显式续期确认流程，比较“自动续期”和“用户确认”的权限边界。
-3. 在 s15 Prompt assembly 中实现明确的优先级：本轮用户指令 > workspace override > user default。
+3. 对照 s15 的显式优先级，设计可信 adapter 把 User Default 投影为候选，并证明模型不能自行声明 `current_turn` 或 `workspace_override`。
 
 ## 下一课
 

--- a/s15_prompt_assembly/README.md
+++ b/s15_prompt_assembly/README.md
@@ -31,6 +31,7 @@ query → candidate → score → stable rank → RecallResult
 RecallResult
   → scope gate
   → confidence gate
+  → authority precedence
   → exact dedupe
   → explicit conflict resolution
   → stable top-k / budget packing
@@ -46,12 +47,13 @@ RecallResult
 flowchart LR
     A["S12 RecallHit"] --> B["S15 Candidate Adapter"]
     B --> C["Scope + Confidence"]
-    C --> D["Dedupe + Conflict"]
-    D --> E["Stable top-k"]
-    E --> F["Char / Token Pack"]
-    F --> G["Recalled Memory Segment"]
-    G --> H["Total Prompt Planner"]
-    H --> I["System Prompt + Two Decision Logs"]
+    C --> D["Authority Precedence"]
+    D --> E["Dedupe + Conflict"]
+    E --> F["Stable top-k"]
+    F --> G["Char / Token Pack"]
+    G --> H["Recalled Memory Segment"]
+    H --> I["Total Prompt Planner"]
+    I --> J["System Prompt + Two Decision Logs"]
 ```
 
 ## S12 与 S15 的职责边界
@@ -59,9 +61,9 @@ flowchart LR
 | 章节 | 负责 | 不负责 |
 |---|---|---|
 | S12 Remote Memory | query 规范化、候选生成、score breakdown、稳定排名、scope 与 provenance | 不决定最终 Prompt 使用哪些 hit |
-| S15 Prompt Assembly | scope/置信度门禁、去重、冲突、top-k、字符/token 预算、Prompt 片段组装 | 不重算检索分数，不写回长期记忆 |
+| S15 Prompt Assembly | scope/置信度门禁、权限层级、去重、冲突、top-k、字符/token 预算、Prompt 片段组装 | 不重算检索分数，不写回长期记忆 |
 
-`memory_candidates_from_recall()` 只做结构适配：复制 S12 的 `scope`、`score`、`rank` 和 `provenance`，不偷偷重排。这样 retrieval 与 selection 可以独立测试和演进。
+`memory_candidates_from_recall()` 只做结构适配：复制 S12 的 `scope`、`score`、`rank` 和 `provenance`，不偷偷重算。S12 记录默认标为 `user_default`；只有可信 Harness 调用方可以通过 `authority_by_memory_id` 显式标记 workspace override 或本轮指令。这样 retrieval 与 selection 可以独立测试和演进。
 
 ## Memory Selection 的核心契约
 
@@ -75,7 +77,8 @@ flowchart LR
 - `score`：S12 产生的召回分数；
 - `source_rank`：S12 的稳定排名；
 - `provenance`：来源 ID、类型、标题与采集时间；
-- `conflict_key`：可选的显式事实槽位。
+- `conflict_key`：可选的显式事实槽位；
+- `authority`：`current_turn`、`workspace_override` 或 `user_default`。
 
 `conflict_key` 不由 S15 从自然语言里猜。例如“自动化语言偏好”可以由结构化记忆生产者标成 `preference:automation-language`。让 Prompt Assembly 再调用一个模型判断矛盾，会把不可观察的第二次推理藏进关键路径。
 
@@ -110,7 +113,41 @@ Plan 同时返回：
 - `context`：预算内的 `<recalled_memory>`；
 - `used_chars` / `used_tokens`：包括 XML wrapper 与 provenance 属性的真实装箱成本；
 - `selected_memory_ids` / `rejected_memory_ids`；
-- `decisions`：每条候选的状态、原因、关联 winner 和解释文本。
+- `decisions`：每条候选的权限层级、状态、原因、关联 winner 和解释文本。
+
+## 三层偏好权限，而不是三个分数权重
+
+同一个事实槽位可能同时有三种有效输入：
+
+| Authority | 含义 | 示例 |
+|---|---|---|
+| `current_turn` | 用户只对当前任务给出的明确要求 | “这次请用 Go 实现” |
+| `workspace_override` | 当前项目的局部约定 | “本仓库自动化统一使用 TypeScript” |
+| `user_default` | 跨项目复用的个人默认偏好 | “我通常偏好 Python” |
+
+仲裁规则固定为：
+
+```text
+current_turn > workspace_override > user_default
+```
+
+这不是给 score 再乘一个权重。低层候选即使 score 更高、rank 更靠前、来源更新，也不能覆盖高层候选；只有处在同一 authority 时才比较检索证据：
+
+```text
+authority desc → score desc → source_rank asc → captured_at desc → memory_id asc
+```
+
+权限字段由 Harness 边界提供，模型不能发明 `system_override` 一类更高等级。未知值会 fail-closed。默认值是 `user_default`，因此原有 S12 adapter 与手写候选保持兼容。
+
+### Authority 不等于 Harness required
+
+`current_turn` 是偏好候选中的最高层，但仍不是系统安全规则。Base instructions、工具边界和 Working mode 继续由 required `PromptSegment` 承载：
+
+- authority 只在候选之间决定谁赢、谁先使用 Memory 预算；
+- required 片段先预留总 Prompt 预算，任何 preference 都不能覆盖或挤掉它；
+- required 本身装不下时抛出 `PromptBudgetError`，不会把安全规则降级成可选偏好。
+
+本轮用户消息仍由 conversation messages 传给模型；`current_turn` 候选是它的结构化仲裁投影和审计证据，不应取代原始用户消息。
 
 ## 选择顺序为什么不能交换
 
@@ -122,25 +159,33 @@ Plan 同时返回：
 
 低于 `min_score` 的记录以 `low_confidence` 拒绝。低置信度不是“排在最后也许能用”，而是默认 abstain，避免预算宽松时把噪声重新放回 Prompt。
 
-### 3. Exact dedupe
+### 3. Authority precedence
+
+通过门禁的候选先按三层 authority 排序。这个顺序同时控制去重 winner、冲突 winner 和后续 top-k/预算装箱，避免低层高分候选抢占空间后让本轮要求消失。
+
+Authority 不能绕过前两道门：跨 scope 或低于 `min_score` 的 `current_turn` 投影仍然会被拒绝。
+
+### 4. Exact dedupe
 
 内容经过 NFKC、大小写折叠和空白归一化后做确定性精确去重。排序更强的候选保留，其他候选记录 `duplicate_content` 以及 winner ID。
 
 这里刻意不声称完成了语义去重。生产环境可以在上游增加 embedding cluster，但必须继续输出可追踪的 winner/loser 关系。
 
-### 4. Explicit conflict resolution
+### 5. Explicit conflict resolution
 
-相同 `conflict_key` 的不同内容竞争同一事实槽位。候选先按以下键稳定排序：
+相同 `conflict_key` 的不同内容竞争同一事实槽位。跨 authority 时，低层候选以 `authority_loser` 拒绝，并记录 winner ID 与双方层级；同层冲突则继续使用 `conflict_loser`。
+
+同层候选按以下键稳定排序：
 
 ```text
 score desc → source_rank asc → captured_at desc → memory_id asc
 ```
 
-第一条成为 winner，其余以 `conflict_loser` 拒绝。冲突败者不会因为 winner 太长或当前预算变化而回填，因为它表达的是已被裁决掉的事实，不只是昂贵上下文。
+第一条成为 winner。冲突败者不会因为 winner 太长或当前预算变化而回填，因为它表达的是已被裁决掉的事实，不只是昂贵上下文。
 
-### 5. Top-k 与预算装箱
+### 6. Top-k 与预算装箱
 
-存活候选按稳定顺序逐条尝试：
+存活候选按 authority 优先的稳定顺序逐条尝试：
 
 - 已经选满时：`top_k_reached`；
 - 加入后字符超限：`char_budget_exceeded`；
@@ -161,7 +206,7 @@ Memory candidates
                  └─ final system prompt
 ```
 
-第一层在 memory 内部选择事实，能解释每条 hit 为什么被拒绝；第二层在系统提示全局比较 persona、memory、project、skills 等片段的价值。如果总 Prompt 预算更紧，整个 memory 片段仍可能被原子舍弃，并由 `SegmentDecision` 记录原因。
+第一层在 memory 内部选择事实，能解释每条 hit 为什么被拒绝；第二层在系统提示全局比较 persona、memory、project、skills 等片段的价值。如果总 Prompt 预算更紧，整个 memory 片段仍可能被原子舍弃，并由 `SegmentDecision` 记录原因。即使 memory 中存在 `current_turn` 投影，它也不能把可选 Memory 片段升级成 required 系统规则。
 
 这两个决策日志不能合并：一个回答“为什么没选这条记忆”，另一个回答“为什么最终没放这个 Prompt 片段”。
 
@@ -225,7 +270,7 @@ python s15_prompt_assembly/code.py
 memory
 ```
 
-教学 fixture 会同时产生：正确候选、重复候选、同槽冲突、低置信度候选和跨用户候选。终端会展示每条记录的 rank、score、selected/rejected、原因码和解释，并展示 memory 与总 Prompt 两层预算。
+教学 fixture 会同时产生：User Default、Workspace Override、本轮指令、同槽跨层冲突、低置信度候选和跨用户候选。终端会展示每条记录的 authority、rank、score、selected/rejected、原因码和解释，并展示 memory 与总 Prompt 两层预算。
 
 继续输入：
 
@@ -248,6 +293,9 @@ PROMPT_BUDGET_CHARS=2000 python s15_prompt_assembly/code.py
 - **把 RecallHit 直接拼进 Prompt**：跳过 scope、冲突和预算决策。
 - **只保留 total score**：无法解释低置信度或冲突 winner。
 - **用输入顺序决定冲突**：JSONL 顺序变化会让事实翻转。
+- **让高 score 覆盖高 authority**：检索相关性不能改变用户指令的权限边界。
+- **让模型自行声明 authority**：模型可以提议内容，不能为自己授予更高权限。
+- **把 `current_turn` 当成 required**：用户偏好层级不能覆盖 Harness 安全规则。
 - **对长记忆直接切字符串**：可能切断 provenance、XML 和事实语义。
 - **把未命中写成空 `<memory>`**：浪费 token，且让模型误以为存在记忆证据。
 - **把字符估算叫真实 token**：不同模型 tokenizer 不同，应显式注入。
@@ -263,6 +311,8 @@ PROMPT_BUDGET_CHARS=2000 python s15_prompt_assembly/code.py
 5. 为什么需要 memory decision log 和 segment decision log 两套审计？
 6. 如何接入真实 tokenizer，而不破坏离线回归和上层 API？
 7. 如何把精确去重升级为语义去重，同时保持 deterministic replay？
+8. 为什么 authority 必须先于 score？它为什么又必须晚于 scope 和 confidence gate？
+9. `current_turn` 与 required PromptSegment 的权限边界分别是什么？
 
 ## 练习
 
@@ -270,6 +320,7 @@ PROMPT_BUDGET_CHARS=2000 python s15_prompt_assembly/code.py
 2. 在上游增加结构化 `fact_type + subject`，生成更可靠的 conflict key。
 3. 增加“必须保留”的 Memory 类型，思考它与 Harness required 安全规则有何不同，以及预算不足时是否应该 fail-closed。
 4. 把 decision reason 汇总为 offline eval 指标，例如 scope rejection rate、low-confidence abstention rate 和 budget utilization。
+5. 为 authority 来源增加签名或事件绑定，证明层级由可信 Harness 产生而不是模型伪造。
 
 ## 下一课
 

--- a/s15_prompt_assembly/code.py
+++ b/s15_prompt_assembly/code.py
@@ -9,8 +9,8 @@ Memory needs one extra boundary before it becomes a prompt segment. S12 returns
 ranked, query-scoped recall hits; S15 decides which of those hits are safe and
 useful enough to enter the current context:
 
-    RecallHit -> scope -> confidence -> dedupe -> conflict -> top-k/budget
-              -> <recalled_memory> -> total prompt segment planner
+    RecallHit -> scope -> confidence -> authority -> dedupe/conflict
+              -> top-k/budget -> <recalled_memory> -> total prompt planner
 
 The selector never writes back to durable memory and never guesses semantic
 conflicts from prose. Callers attach an explicit ``conflict_key`` when several
@@ -38,6 +38,7 @@ PROGRESSION = {
     "builds_on": ["s14_context_compact"],
     "adds": [
         "scope- and confidence-gated memory selection",
+        "explicit current-turn, workspace, and user-default precedence",
         "stable deduplication and explicit conflict resolution",
         "top-k character/token context packing",
         "per-candidate selection and rejection decisions",
@@ -147,10 +148,43 @@ class MemoryDecisionReason(str, Enum):
     SCOPE_MISMATCH = "scope_mismatch"
     LOW_CONFIDENCE = "low_confidence"
     DUPLICATE_CONTENT = "duplicate_content"
+    AUTHORITY_LOSER = "authority_loser"
     CONFLICT_LOSER = "conflict_loser"
     TOP_K_REACHED = "top_k_reached"
     CHAR_BUDGET_EXCEEDED = "char_budget_exceeded"
     TOKEN_BUDGET_EXCEEDED = "token_budget_exceeded"
+
+
+class PreferenceAuthority(str, Enum):
+    """Who supplied a preference, ordered by authority at the current turn.
+
+    Harness-required safety rules deliberately do not appear here. They remain
+    required ``PromptSegment`` objects and cannot be overridden by any memory
+    or user-preference candidate.
+    """
+
+    CURRENT_TURN = "current_turn"
+    WORKSPACE_OVERRIDE = "workspace_override"
+    USER_DEFAULT = "user_default"
+
+
+_PREFERENCE_AUTHORITY_PRIORITY = {
+    PreferenceAuthority.CURRENT_TURN: 3,
+    PreferenceAuthority.WORKSPACE_OVERRIDE: 2,
+    PreferenceAuthority.USER_DEFAULT: 1,
+}
+
+
+def _preference_authority(value: object) -> PreferenceAuthority:
+    """Normalize a boundary value and reject invented authority levels."""
+
+    if isinstance(value, PreferenceAuthority):
+        return value
+    try:
+        return PreferenceAuthority(str(value).strip())
+    except ValueError as exc:
+        allowed = ", ".join(item.value for item in PreferenceAuthority)
+        raise ValueError(f"memory authority must be one of: {allowed}") from exc
 
 
 def _required_text(value: object, *, field_name: str) -> str:
@@ -211,6 +245,7 @@ class MemoryContextCandidate:
     source_rank: int
     provenance: MemoryContextProvenance
     conflict_key: str | None = None
+    authority: PreferenceAuthority = PreferenceAuthority.USER_DEFAULT
 
     def __post_init__(self) -> None:
         _required_text(self.memory_id, field_name="memory_id")
@@ -222,6 +257,7 @@ class MemoryContextCandidate:
             raise ValueError("memory source_rank must be positive")
         if self.conflict_key is not None:
             _required_text(self.conflict_key, field_name="memory conflict_key")
+        object.__setattr__(self, "authority", _preference_authority(self.authority))
 
 
 @dataclass(frozen=True)
@@ -253,6 +289,7 @@ class MemorySelectionDecision:
     reason: MemoryDecisionReason
     score: float
     source_rank: int
+    authority: PreferenceAuthority
     candidate_chars: int
     candidate_tokens: int
     related_memory_id: str | None = None
@@ -314,9 +351,10 @@ def _count_tokens(token_counter: TokenCounter, text: str) -> int:
 
 
 def _candidate_order(candidate: MemoryContextCandidate) -> tuple[object, ...]:
-    """Rank independently of provider/storage iteration order."""
+    """Rank by authority, then retrieval evidence, never input order."""
 
     return (
+        -_PREFERENCE_AUTHORITY_PRIORITY[candidate.authority],
         -candidate.score,
         candidate.source_rank,
         -_parse_utc_timestamp(candidate.provenance.captured_at).timestamp(),
@@ -336,6 +374,7 @@ def render_memory_hit(candidate: MemoryContextCandidate) -> str:
     return (
         f'<memory_hit memory_id="{html.escape(candidate.memory_id, quote=True)}" '
         f'score="{candidate.score:.6f}" source_rank="{candidate.source_rank}" '
+        f'authority="{candidate.authority.value}" '
         f'user_scope="{html.escape(candidate.user_scope, quote=True)}" '
         f'source_id="{html.escape(provenance.source_id, quote=True)}" '
         f'source_type="{html.escape(provenance.source_type, quote=True)}" '
@@ -389,6 +428,7 @@ def _decision(
         reason=reason,
         score=candidate.score,
         source_rank=candidate.source_rank,
+        authority=candidate.authority,
         candidate_chars=len(rendered),
         candidate_tokens=_count_tokens(token_counter, rendered),
         related_memory_id=related_memory_id,
@@ -406,11 +446,14 @@ def select_memory_context(
     """Select and atomically pack recalled memory under explicit constraints.
 
     The order is intentional: security scope and confidence are gates; exact
-    duplicates and typed conflicts are resolved before scarce budget is spent;
-    top-k and budgets then pack the strongest surviving records. An oversized
-    record does not stop packing, so a smaller lower-ranked record can still use
-    the remaining budget. Conflict losers never backfill because they represent
-    facts superseded by the chosen winner, not merely expensive context.
+    duplicates and typed conflicts are resolved before scarce budget is spent.
+    Authority orders eligible candidates as ``current_turn`` >
+    ``workspace_override`` > ``user_default``; score, source rank, capture time,
+    and ID only break ties inside one authority. Top-k and budgets then pack the
+    surviving records in that same order. An oversized record does not stop
+    packing, so a smaller lower-ranked record can still use the remaining
+    budget. Conflict losers never backfill because they represent facts
+    superseded by the chosen winner, not merely expensive context.
     """
 
     scope = _required_text(user_scope, field_name="user_scope")
@@ -479,13 +522,30 @@ def select_memory_context(
         normalized_key = _normalized_memory_text(conflict_key)
         winner = conflict_winners.get(normalized_key)
         if winner is not None:
+            authority_lost = (
+                _PREFERENCE_AUTHORITY_PRIORITY[candidate.authority]
+                < _PREFERENCE_AUTHORITY_PRIORITY[winner.authority]
+            )
+            reason = (
+                MemoryDecisionReason.AUTHORITY_LOSER
+                if authority_lost
+                else MemoryDecisionReason.CONFLICT_LOSER
+            )
+            if authority_lost:
+                detail = (
+                    f"conflict slot {conflict_key!r}: "
+                    f"{candidate.authority.value} lost to "
+                    f"{winner.authority.value} candidate {winner.memory_id}"
+                )
+            else:
+                detail = f"conflict slot {conflict_key!r} won by {winner.memory_id}"
             decisions[candidate.memory_id] = _decision(
                 candidate,
                 status=MemoryDecisionStatus.REJECTED,
-                reason=MemoryDecisionReason.CONFLICT_LOSER,
+                reason=reason,
                 token_counter=token_counter,
                 related_memory_id=winner.memory_id,
-                detail=f"conflict slot {conflict_key!r} won by {winner.memory_id}",
+                detail=detail,
             )
             continue
         conflict_winners[normalized_key] = candidate
@@ -562,13 +622,15 @@ def memory_candidates_from_recall(
     result: object,
     *,
     conflict_keys: Mapping[str, str] | None = None,
+    authority_by_memory_id: Mapping[str, PreferenceAuthority | str] | None = None,
 ) -> tuple[MemoryContextCandidate, ...]:
     """Adapt S12's public RecallResult shape without coupling chapter imports.
 
     The bridge uses structural attributes so S15 remains independently runnable.
-    Scope, score, provider rank, and provenance are copied rather than recomputed;
-    selection policy belongs here, while retrieval evidence continues to belong
-    to S12.
+    Scope, score, provider rank, and provenance are copied rather than recomputed.
+    S12 records default to ``user_default``; a trusted caller can explicitly
+    label a workspace override or current-turn instruction. Selection policy
+    belongs here, while retrieval evidence continues to belong to S12.
     """
 
     query = getattr(result, "query", None)
@@ -607,6 +669,9 @@ def memory_candidates_from_recall(
                     captured_at=str(getattr(provenance, "captured_at", "")),
                 ),
                 conflict_key=(conflict_keys or {}).get(memory_id),
+                authority=(authority_by_memory_id or {}).get(
+                    memory_id, PreferenceAuthority.USER_DEFAULT
+                ),
             )
         )
     return tuple(converted)
@@ -1052,12 +1117,13 @@ def assemble_system_prompt(
     if verbose:
         if LAST_MEMORY_CONTEXT_PLAN is not None:
             print(
-                f"\n\033[90m{'memory':<18} {'rank':>5} {'score':>8} "
+                f"\n\033[90m{'memory':<18} {'authority':<18} {'rank':>5} {'score':>8} "
                 f"{'status':>9} reason / detail\033[0m"
             )
             for decision in LAST_MEMORY_CONTEXT_PLAN.decisions:
                 print(
                     f"\033[90m{decision.memory_id:<18} "
+                    f"{decision.authority.value:<18} "
                     f"{decision.source_rank:>5} {decision.score:>8.3f} "
                     f"{decision.status.value:>9} {decision.reason.value} / "
                     f"{decision.detail}\033[0m"
@@ -1202,6 +1268,7 @@ def load_demo_recalled_memory() -> None:
         rank: int,
         conflict_key: str | None = None,
         user_scope: str = "demo-user-scope",
+        authority: PreferenceAuthority = PreferenceAuthority.USER_DEFAULT,
     ) -> MemoryContextCandidate:
         return MemoryContextCandidate(
             memory_id=memory_id,
@@ -1216,30 +1283,33 @@ def load_demo_recalled_memory() -> None:
                 captured_at=f"2026-08-{18-rank:02d}T09:00:00Z",
             ),
             conflict_key=conflict_key,
+            authority=authority,
         )
 
     set_recalled_memory(
         [
             demo_candidate(
-                "python-current",
-                "Prefer Python for automation tasks.",
+                "python-default",
+                "Prefer Python for automation tasks by default.",
                 score=0.93,
                 rank=1,
                 conflict_key="preference:automation-language",
             ),
             demo_candidate(
-                "python-copy",
-                " prefer PYTHON for automation tasks. ",
+                "typescript-workspace",
+                "Use TypeScript for automation in this workspace.",
                 score=0.86,
                 rank=2,
                 conflict_key="preference:automation-language",
+                authority=PreferenceAuthority.WORKSPACE_OVERRIDE,
             ),
             demo_candidate(
-                "typescript-old",
-                "Prefer TypeScript for automation tasks.",
+                "python-current-turn",
+                "For this turn, implement the automation in Python.",
                 score=0.72,
                 rank=3,
                 conflict_key="preference:automation-language",
+                authority=PreferenceAuthority.CURRENT_TURN,
             ),
             demo_candidate(
                 "source-grounding",

--- a/s15_prompt_assembly/images/prompt-assembly.svg
+++ b/s15_prompt_assembly/images/prompt-assembly.svg
@@ -12,8 +12,8 @@
   </defs>
 
   <rect width="1000" height="700" fill="#f8fafc"/>
-  <text x="500" y="38" text-anchor="middle" font-size="24" font-weight="700" fill="#111827">S15：Memory Selection 与 Context Budget Assembly</text>
-  <text x="500" y="62" text-anchor="middle" font-size="13" fill="#475569">召回是候选，只有通过策略与预算的记录才进入 Prompt</text>
+  <text x="500" y="38" text-anchor="middle" font-size="24" font-weight="700" fill="#111827">S15：Preference Precedence 与 Context Budget Assembly</text>
+  <text x="500" y="62" text-anchor="middle" font-size="13" fill="#475569">本轮指令 &gt; Workspace Override &gt; User Default，然后才按证据与预算装箱</text>
 
   <!-- Selection pipeline -->
   <rect x="35" y="92" width="170" height="92" rx="10" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/>
@@ -38,9 +38,9 @@
   <line x1="565" y1="138" x2="602" y2="138" stroke="#1f2937" stroke-width="2" marker-end="url(#arrow)"/>
 
   <rect x="610" y="92" width="155" height="92" rx="10" fill="#fef3c7" stroke="#d97706" stroke-width="2"/>
-  <text x="687.5" y="120" text-anchor="middle" font-size="15" font-weight="700" fill="#92400e">Dedupe / Conflict</text>
-  <text x="687.5" y="145" text-anchor="middle" font-size="12" fill="#b45309">exact content</text>
-  <text x="687.5" y="164" text-anchor="middle" font-size="12" fill="#b45309">explicit fact slot</text>
+  <text x="687.5" y="120" text-anchor="middle" font-size="15" font-weight="700" fill="#92400e">Authority / Conflict</text>
+  <text x="687.5" y="145" text-anchor="middle" font-size="12" fill="#b45309">turn &gt; workspace &gt; user</text>
+  <text x="687.5" y="164" text-anchor="middle" font-size="12" fill="#b45309">dedupe · explicit slot</text>
 
   <line x1="765" y1="138" x2="802" y2="138" stroke="#1f2937" stroke-width="2" marker-end="url(#arrow)"/>
 
@@ -57,14 +57,14 @@
 
   <rect x="90" y="225" width="820" height="88" rx="10" fill="#fff1f2" stroke="#e11d48" stroke-width="1.7"/>
   <text x="500" y="250" text-anchor="middle" font-size="15" font-weight="700" fill="#9f1239">MemorySelectionDecision：每个候选都有终态</text>
-  <text x="500" y="275" text-anchor="middle" font-size="12" fill="#be123c">scope_mismatch · low_confidence · duplicate_content · conflict_loser</text>
+  <text x="500" y="275" text-anchor="middle" font-size="12" fill="#be123c">scope_mismatch · low_confidence · duplicate_content · authority_loser · conflict_loser</text>
   <text x="500" y="296" text-anchor="middle" font-size="12" fill="#be123c">top_k_reached · char_budget_exceeded · token_budget_exceeded · selected</text>
 
   <!-- Selected memory context -->
   <path d="M965 138 H980 V330 H790 V338" fill="none" stroke="#2563eb" stroke-width="2.2" marker-end="url(#arrowBlue)"/>
   <rect x="210" y="345" width="580" height="92" rx="12" fill="#dbeafe" stroke="#2563eb" stroke-width="2.2"/>
   <text x="500" y="373" text-anchor="middle" font-size="17" font-weight="700" fill="#1e3a8a">&lt;recalled_memory&gt;</text>
-  <text x="500" y="398" text-anchor="middle" font-size="13" fill="#1e40af">原子 memory_hit · scope · score · rank · provenance</text>
+  <text x="500" y="398" text-anchor="middle" font-size="13" fill="#1e40af">原子 memory_hit · authority · scope · score · rank · provenance</text>
   <text x="500" y="420" text-anchor="middle" font-size="12" fill="#1e40af">used_chars / used_tokens 与 selected IDs 可回放</text>
 
   <!-- Total prompt planner -->

--- a/tests/test_memory_context_selection.py
+++ b/tests/test_memory_context_selection.py
@@ -74,6 +74,7 @@ def candidate(
     source_rank: int = 1,
     captured_at: str = "2026-08-17T08:00:00Z",
     conflict_key: str | None = None,
+    authority: str = "user_default",
 ):
     return s15.MemoryContextCandidate(
         memory_id=memory_id,
@@ -88,6 +89,7 @@ def candidate(
             captured_at=captured_at,
         ),
         conflict_key=conflict_key,
+        authority=authority,
     )
 
 
@@ -175,6 +177,126 @@ def test_deduplication_and_conflict_resolution_are_stable(s15) -> None:
     assert decisions["typescript-old"].related_memory_id == "python-new"
 
 
+def test_authority_precedes_score_rank_time_and_input_order(s15) -> None:
+    conflict_key = "preference:automation-language"
+    user_default = candidate(
+        s15,
+        "python-default",
+        "Prefer Python for automation",
+        score=0.99,
+        source_rank=1,
+        captured_at="2026-08-19T10:00:00Z",
+        conflict_key=conflict_key,
+        authority="user_default",
+    )
+    workspace = candidate(
+        s15,
+        "typescript-workspace",
+        "Use TypeScript in this workspace",
+        score=0.80,
+        source_rank=2,
+        captured_at="2026-08-18T10:00:00Z",
+        conflict_key=conflict_key,
+        authority="workspace_override",
+    )
+    current_turn = candidate(
+        s15,
+        "go-current-turn",
+        "For this turn, use Go",
+        score=0.41,
+        source_rank=3,
+        captured_at="2026-08-17T10:00:00Z",
+        conflict_key=conflict_key,
+        authority="current_turn",
+    )
+    policy = s15.MemorySelectionPolicy(min_score=0.4, top_k=3)
+
+    forward = s15.select_memory_context(
+        [user_default, workspace, current_turn],
+        user_scope="scope-a",
+        policy=policy,
+    )
+    reverse = s15.select_memory_context(
+        [current_turn, workspace, user_default],
+        user_scope="scope-a",
+        policy=policy,
+    )
+    decisions = decision_by_id(forward)
+
+    assert forward.context == reverse.context
+    assert forward.selected_memory_ids == ("go-current-turn",)
+    assert 'authority="current_turn"' in forward.context
+    assert decisions["typescript-workspace"].reason is (
+        s15.MemoryDecisionReason.AUTHORITY_LOSER
+    )
+    assert decisions["python-default"].reason is (
+        s15.MemoryDecisionReason.AUTHORITY_LOSER
+    )
+    assert decisions["python-default"].related_memory_id == "go-current-turn"
+    assert "user_default lost to current_turn" in decisions["python-default"].detail
+
+
+def test_authority_orders_independent_candidates_under_top_k(s15) -> None:
+    high_score_default = candidate(
+        s15,
+        "high-score-default",
+        "Default answer style",
+        score=0.99,
+        conflict_key="preference:style",
+    )
+    current_turn = candidate(
+        s15,
+        "current-turn-format",
+        "Use a table for this answer",
+        score=0.50,
+        conflict_key="preference:format",
+        authority="current_turn",
+    )
+
+    plan = s15.select_memory_context(
+        [high_score_default, current_turn],
+        user_scope="scope-a",
+        policy=s15.MemorySelectionPolicy(min_score=0.1, top_k=1),
+    )
+    decisions = decision_by_id(plan)
+
+    assert plan.selected_memory_ids == ("current-turn-format",)
+    assert decisions["high-score-default"].reason is (
+        s15.MemoryDecisionReason.TOP_K_REACHED
+    )
+
+
+def test_authority_never_bypasses_scope_or_confidence_gates(s15) -> None:
+    cross_scope = candidate(
+        s15,
+        "cross-scope-current",
+        "Private current-turn instruction",
+        score=1.0,
+        user_scope="scope-b",
+        authority="current_turn",
+    )
+    low_confidence = candidate(
+        s15,
+        "weak-current",
+        "Uncertain current-turn extraction",
+        score=0.2,
+        authority="current_turn",
+    )
+
+    plan = s15.select_memory_context(
+        [cross_scope, low_confidence],
+        user_scope="scope-a",
+        policy=s15.MemorySelectionPolicy(min_score=0.4),
+    )
+    decisions = decision_by_id(plan)
+
+    assert plan.selected_memory_ids == ()
+    assert decisions["cross-scope-current"].reason is (
+        s15.MemoryDecisionReason.SCOPE_MISMATCH
+    )
+    assert decisions["weak-current"].reason is s15.MemoryDecisionReason.LOW_CONFIDENCE
+
+
 def test_character_budget_skips_oversized_hit_and_backfills_until_top_k(s15) -> None:
     oversized = candidate(s15, "oversized", "X" * 1_000, score=0.99)
     second = candidate(s15, "second", "Short useful memory", score=0.90)
@@ -246,6 +368,7 @@ def test_recall_adapter_preserves_scope_score_rank_and_provenance(s15) -> None:
     converted = s15.memory_candidates_from_recall(
         result,
         conflict_keys={"memory-1": "preference:grounding"},
+        authority_by_memory_id={"memory-1": "workspace_override"},
     )
 
     assert converted == (
@@ -262,8 +385,56 @@ def test_recall_adapter_preserves_scope_score_rank_and_provenance(s15) -> None:
                 captured_at="2026-08-16T09:00:00Z",
             ),
             conflict_key="preference:grounding",
+            authority=s15.PreferenceAuthority.WORKSPACE_OVERRIDE,
         ),
     )
+    defaulted = s15.memory_candidates_from_recall(
+        result,
+        conflict_keys={"memory-1": "preference:grounding"},
+    )
+    assert defaulted[0].authority is s15.PreferenceAuthority.USER_DEFAULT
+
+
+def test_unknown_authority_fails_closed(s15) -> None:
+    with pytest.raises(ValueError, match="memory authority must be one of"):
+        candidate(
+            s15,
+            "invented-authority",
+            "An untrusted caller cannot invent a higher tier",
+            authority="system_override",
+        )
+
+
+def test_required_harness_rules_are_not_part_of_preference_precedence(s15) -> None:
+    current_turn = candidate(
+        s15,
+        "current-turn",
+        "Use a concise response for this turn",
+        score=1.0,
+        authority="current_turn",
+    )
+    memory_plan = s15.select_memory_context(
+        [current_turn],
+        user_scope="scope-a",
+        policy=s15.MemorySelectionPolicy(min_score=0.1),
+    )
+    safety = s15.PromptSegment(
+        "safety", lambda: "HARNESS SAFETY", required=True, priority=10
+    )
+    preferences = s15.PromptSegment(
+        "preferences",
+        lambda: memory_plan.context,
+        budget_priority=100,
+        priority=20,
+    )
+
+    prompt_plan = s15.plan_prompt(
+        [preferences, safety], budget_chars=len("HARNESS SAFETY")
+    )
+
+    assert prompt_plan.prompt == "HARNESS SAFETY"
+    assert prompt_plan.included_names == ("safety",)
+    assert prompt_plan.dropped_names == ("preferences",)
 
 
 def test_selected_memory_evidence_survives_lossy_compaction(


### PR DESCRIPTION
## Summary

- add explicit `current_turn > workspace_override > user_default` precedence to S15 memory selection
- keep scope and confidence as fail-closed gates, and keep Harness-required prompt segments outside preference authority
- expose authority in rendered context and deterministic decision logs, including `authority_loser`
- preserve S12 adapter compatibility by defaulting recalled records to `user_default`
- update the S11 handoff, S15 teaching guide, architecture diagram, offline demo, and tests

## Validation

- 92 Memory/RAG/Context tests passed
- 43 clean-worktree structure, import, security-parity, and S15 tests passed
- 7 S14 compaction compatibility tests passed
- Python compilation, `git diff --check`, SVG XML validation, and rendered SVG inspection passed