### PR TITLE
feat(s10): add memory conflict adjudication

### DIFF
--- a/s10_workspace_memory/README.md
+++ b/s10_workspace_memory/README.md
@@ -17,7 +17,12 @@ flowchart LR
     D -->|"not stable"| C
     E --> H{"one strongest newer value?"}
     H -->|"yes"| I["new active revision"]
-    H -->|"tie / stale"| C
+    H -->|"stale"| C
+    H -->|"tie"| Q["conflicts.json review queue"]
+    Q --> R["human resolve_conflict"]
+    R --> K["append-only adjudication audit"]
+    R -->|"challenger"| I
+    R -->|"incumbent"| J
     I --> J["curated.json history"]
     J --> F["active-only MEMORY.md"]
     F --> G["bounded prompt context"]
@@ -33,6 +38,8 @@ s09 的 JSONL transcript 属于某个 session，是完整执行证据；本章�
 - 只有稳定、足够旧且重要或重复出现的事实进入长期视图。
 - 可替换的项目决策使用显式 `memory_key` 形成冲突域，新值只会在重复确认且时间更新时替代旧值。
 - 被替代的修订和原始证据继续保留，prompt 只注入每个冲突域的 active 修订。
+- 同强度冲突会形成持久化 review case；只有显式的人类裁决能选择候选。
+- 裁决绑定 evidence fingerprint、case revision 和 event ID；陈旧页面或重试不会覆盖新证据。
 - 策展状态通过原子替换更新，失败时仍保留上一份完整文件。
 - 不依赖 API key 就能验证记忆策略。
 
@@ -48,6 +55,8 @@ project/
         │   ├── 2026-08-07.jsonl
         │   └── 2026-08-08.jsonl
         ├── curated.json
+        ├── conflicts.json
+        ├── conflict-adjudications.jsonl
         └── MEMORY.md
 ```
 
@@ -55,6 +64,8 @@ project/
 |---|---|---|---|
 | `daily/*.jsonl` | 原始事实日志 | `O_APPEND` 单记录追加 | 是 |
 | `curated.json` | 策展状态的机器真相 | 临时文件 + `os.replace` | 可追溯到 evidence id |
+| `conflicts.json` | 待审与历史冲突快照 | 临时文件 + `os.replace` | 是，保存候选、revision 与 fingerprint |
+| `conflict-adjudications.jsonl` | 人工裁决审计流 | `O_APPEND` 单事件追加 | 是，记录 actor、rationale 与选中证据 |
 | `MEMORY.md` | 面向人和 prompt 的派生视图 | 从策展状态原子重建 | 否，随时可重建 |
 
 教学实现使用 `.learn_workbuddy` 命名空间，避免练习代码碰到真实产品状态。`WorkspaceMemory` 会先解析项目绝对路径，再生成 `workspace_id`；日志和策展文件在读取时都校验该 id。
@@ -106,12 +117,56 @@ AND (importance >= 4 OR 规范化后重复出现 >= 2 次)
 1. 与 active 内容相同的新事实只合并 `evidence_ids`，不会产生新修订。
 2. 不同内容必须同时通过普通晋升门槛，并至少有 `supersession_repeat_threshold` 条独立事实确认；默认值为 2，即单条高重要度事实也不能直接覆盖现有决策。
 3. 候选的最新时间必须晚于 active 修订的 `last_seen`，过期证据不能回滚当前值。
-4. 多个候选按重要度、独立证据数和最新时间排序；最优分数相同时 fail closed，保留当前修订并在报告中增加 `conflicts`。
+4. 多个候选按重要度、独立证据数和最新时间排序；最优分数相同时 fail closed，保留当前修订并创建持久化 `MemoryConflictCase`。
 5. 唯一胜出者成为下一版 active 修订；旧版标记为 `superseded`，双方通过 `supersedes` / `superseded_by` 互相指向。
 
-每条修订都保留 `revision` 和 `evidence_ids`，因此重复运行 `distill` 是幂等的，完整决策历史也可审计。`DistillReport` 额外报告 `superseded`、`conflicts` 与 `stale`，让拒绝覆盖的原因可观察。
+每条修订都保留 `revision` 和 `evidence_ids`，因此重复运行 `distill` 是幂等的，完整决策历史也可审计。`DistillReport` 额外报告 `superseded`、`conflicts`、`queued_conflicts`、`conflict_case_ids` 与 `stale`，让拒绝覆盖的原因可观察。
 
-### 3. 保留原始证据
+### 3. 同分冲突进入人工裁决队列
+
+一个 case 不是一句“发生冲突”的提示，而是完整、可恢复的观察快照：
+
+- `conflict_id`：由 workspace、memory key 和 evidence fingerprint 确定性生成；
+- `revision`：同一 memory key 的案件版本；
+- `candidates`：当前 active incumbent 与同分 challenger；
+- `evidence_ids`：每个候选的不可变来源集合；
+- `observed_fact_ids`：检测时该冲突域的全部已见事实；
+- `active_entry_key`：检测时的 active curated revision；
+- `open / resolved / superseded`：案件生命周期。
+
+重复执行 `distill()` 不会重复创建相同案件。证据发生变化且仍然同分时，旧 open case 标为 `superseded`，新 fingerprint 形成下一 revision。调用方只能通过 `list_conflicts()` 获取 open case；这些候选不会进入 `MEMORY.md` 或 Agent Prompt。
+
+### 4. 显式裁决与 append-only 审计
+
+裁决必须提交刚刚看到的 case revision：
+
+```python
+case = memory.list_conflicts()[0]
+choice = next(c for c in case.candidates if c.content == "Use Postgres.")
+
+event = memory.resolve_conflict(
+    case.conflict_id,
+    choice.candidate_id,
+    expected_revision=case.revision,
+    actor="reviewer@example.com",
+    rationale="Production requires PostgreSQL extensions.",
+    event_id="review:storage-database:42",
+)
+```
+
+执行前会重新检查：
+
+1. case 仍为 open，revision 没有变化；
+2. 当前 active entry 仍是检测时的版本；
+3. 当前 workspace 的 observed fact IDs 与 fingerprint 快照一致；
+4. selected candidate 确实属于该 case；
+5. event ID 未被用于另一种裁决。
+
+任何新增证据都会触发 `StaleConflictResolutionError`，要求 reviewer 重新查看候选。选择 challenger 时创建下一版 curated revision；选择 incumbent 时只记录“保持现状”，不会制造虚假修订。成功事件追加到 `conflict-adjudications.jsonl`，包含 actor、rationale、case revision、选中 evidence IDs、原 active key 与结果 active key。
+
+同一个 event ID 携带完全相同的参数重试会返回原事件，不会重复写审计或创建修订；复用 event ID 改选另一个候选会显式拒绝。裁决 API 只属于可信 Harness/人工入口，`MemoryAwareAgent` 的模型工具列表不包含它。
+
+### 5. 保留原始证据
 
 蒸馏是建立派生视图，不是日志清理：
 
@@ -123,7 +178,7 @@ daily fact log ──select──> curated.json ──render──> MEMORY.md
 
 删除旧日志会让长期结论失去来源，也让错误蒸馏无法重新计算。真正的存储清理由单独的 retention/backup 策略负责，不和 memory distill 混在一起。
 
-### 4. 原子更新与重启恢复
+### 6. 原子更新与重启恢复
 
 直接以 `"w"` 打开 `MEMORY.md`，进程崩溃时可能只剩半个文件。本章采用同目录临时文件：
 
@@ -134,7 +189,7 @@ daily fact log ──select──> curated.json ──render──> MEMORY.md
 
 Windows 的回退仍会在替换前完整写入、刷新并同步临时文件，再执行同目录 `os.replace`，因此不会把半个新文件暴露为 canonical state。POSIX 平台额外同步目录项，以加强断电后的 rename 持久性。
 
-`curated.json` 是 canonical state，`MEMORY.md` 是可重建投影。如果进程在两次替换之间退出，下一次读取会以 canonical state 修复陈旧投影。新建一个 `WorkspaceMemory(project_dir)` 实例即可从磁盘恢复事实、策展条目和 prompt context；不会反序列化任何进程内对象。
+`curated.json` 是 memory canonical state，`conflicts.json` 是 review queue canonical state，`MEMORY.md` 是可重建投影。如果进程在策展状态和投影两次替换之间退出，下一次读取会以 canonical state 修复陈旧投影。新建一个 `WorkspaceMemory(project_dir)` 实例即可从磁盘恢复事实、策展条目、冲突 case、裁决日志和 prompt context；不会反序列化任何进程内对象。
 
 当前 schema 为 v2；读取器仍接受 v1 daily fact 和 curated state。旧条目按无 key 的 legacy 语义恢复，在下一次成功蒸馏写入时统一保存为 v2，而不会自动推断冲突域。读取 keyed 状态时还会校验每个域恰好一个 active 修订、修订号连续、前后链接互相匹配；损坏状态会显式报错，不会静默选择一个答案。
 
@@ -145,7 +200,7 @@ Windows 的回退仍会在替换前完整写入、刷新并同步临时文件，
 - 紧凑的 `MEMORY.md`；
 - 最近最多 6 条 workspace facts。
 
-它不会把所有 daily log 或 session transcript 整体塞回上下文。Keyed 原始事实在完成蒸馏前也不会作为 recent facts 绕过冲突策略；prompt 只能看到每个冲突域当前的 active 修订。Memory 的价值不在“存得越多”，而在召回时有明确预算和优先级。
+它不会把所有 daily log、冲突候选或 session transcript 整体塞回上下文。Keyed 原始事实在完成蒸馏前也不会作为 recent facts 绕过冲突策略；prompt 只能看到每个冲突域当前的 active 修订。Memory 的价值不在“存得越多”，而在召回时有明确预算和优先级。
 
 `MemoryAwareAgent` 在每个模型回合前读取这个 bounded view，并提供结构化 `write_memory` 工具。是否继续工具循环由响应中的 `tool_use` block 决定，不依赖 provider 的某个 stop-reason 字符串。
 
@@ -162,14 +217,21 @@ distill
   -> reject unstable kinds
   -> preserve legacy content groups; group keyed facts by conflict domain
   -> apply importance/repetition gate
-  -> reject stale or tied challengers
+  -> reject stale challengers; persist tied candidates as a conflict case
   -> merge evidence or append a linked revision
-  -> atomically replace curated.json and MEMORY.md
+  -> atomically replace curated.json / conflicts.json / MEMORY.md
+
+human review
+  -> list open conflict snapshot
+  -> submit expected revision + selected candidate + source event
+  -> reject changed evidence or reused event IDs
+  -> keep incumbent or append a linked curated revision
+  -> append ConflictAdjudication JSONL event
 
 restart
   -> resolve the same project scope
   -> validate workspace_id and schema
-  -> reload daily facts + curated state
+  -> reload daily facts + curated state + conflict queue + adjudication audit
   -> rebuild bounded prompt context
 ```
 
@@ -187,12 +249,18 @@ python3 s10_workspace_memory/code.py --demo
 python3 -m pytest -q tests/test_workspace_memory.py
 ```
 
-测试覆盖：项目隔离、追加顺序、蒸馏门槛、幂等、证据保留、原子替换失败、key 校验、新值确认、冲突 fail closed、过期证据防回滚、修订链校验、v1 迁移和跨实例恢复。
+测试覆盖：项目隔离、追加顺序、蒸馏门槛、幂等、证据保留、原子替换失败、key 校验、新值确认、冲突 fail closed、案件去重、选择 challenger、保留 incumbent、裁决审计幂等、新证据陈旧保护、案件 revision、跨 workspace 拒绝、修订链校验、v1 迁移和跨实例恢复。
 
 配置模型后可运行交互路径：
 
 ```bash
 python3 s10_workspace_memory/code.py
+```
+
+交互 CLI 使用 `/conflicts` 查看 open case，再用下面的格式裁决：
+
+```text
+/resolve <conflict_id> <revision> <candidate_id> <event_id> <rationale>
 ```
 
 ## 三层记忆中的位置
@@ -212,11 +280,15 @@ python3 s10_workspace_memory/code.py
 - **用答案文本充当 `memory_key`**：值改变时会变成另一个冲突域，失去替代关系；key 应描述稳定问题，例如 `runtime.python-version`。
 - **让单条新事实覆盖已有决策**：高重要度不等于已确认，替代必须满足独立重复证据门槛。
 - **把所有候选都注入 prompt 再让模型选择**：这会绕过 harness 的冲突策略；未决候选应留在证据日志中。
+- **只在内存里返回 conflicts 数量**：应用重启后 reviewer 不知道要处理什么，也无法证明当时看到了哪些证据。
+- **裁决时不校验 revision/fingerprint**：旧页面可能覆盖后来到达的新事实。
+- **让模型调用 resolve 工具**：候选内容不能给自己授予裁决权限，人工入口必须位于可信 Harness 边界。
+- **选择 incumbent 也创建新修订**：这会伪造一次事实变化；保持现状只需要审计事件。
 
 ## 练习
 
 1. 为 `DistillPolicy` 增加来源置信度，让用户确认的事实比工具推断更容易晋升。
-2. 为冲突报告增加待人工裁决队列，并设计显式选择某个候选的审计记录。
+2. 把多文件裁决流程升级为带 crash recovery 的 transaction journal，验证任意写入点中断后都能安全重放。
 3. 在不加载全部日志的前提下实现按日期倒序读取最近事实。
 
 ## 下一课

--- a/s10_workspace_memory/code.py
+++ b/s10_workspace_memory/code.py
@@ -41,6 +41,7 @@ PROGRESSION = {
         "workspace-scoped fact log",
         "policy-driven memory distillation",
         "keyed memory supersession",
+        "human conflict adjudication with append-only audit",
         "atomic curated memory view",
     ],
     "preserves": ["append-only evidence and restart recovery"],
@@ -84,7 +85,12 @@ DEFAULT_RETENTION_DAYS = 30
 MAX_FACT_CHARS = 2_000
 MAX_CONTEXT_FACTS = 6
 MAX_MEMORY_KEY_CHARS = 120
+MAX_ADJUDICATION_TEXT_CHARS = 1_000
+MAX_EVENT_ID_CHARS = 200
 MEMORY_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
+EVENT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,199}$")
+CONFLICT_SCHEMA_VERSION = 1
+ADJUDICATION_SCHEMA_VERSION = 1
 WORKDIR = Path.cwd()
 _DIRECTORY_FSYNC_SUPPORTED = os.name != "nt"
 
@@ -119,6 +125,14 @@ class MemoryCorruptionError(MemoryErrorBase):
     """Raised for malformed durable records that cannot be ignored safely."""
 
 
+class ConflictResolutionError(MemoryErrorBase):
+    """Raised when a requested adjudication is invalid or contradictory."""
+
+
+class StaleConflictResolutionError(ConflictResolutionError):
+    """Raised when evidence changed after a reviewer observed a conflict."""
+
+
 class FactKind(str, Enum):
     """Small vocabulary that makes retention policy explicit.
 
@@ -137,6 +151,14 @@ class CuratedStatus(str, Enum):
     """Lifecycle state for one immutable curated revision."""
 
     ACTIVE = "active"
+    SUPERSEDED = "superseded"
+
+
+class ConflictStatus(str, Enum):
+    """Lifecycle of one immutable conflict snapshot."""
+
+    OPEN = "open"
+    RESOLVED = "resolved"
     SUPERSEDED = "superseded"
 
 
@@ -271,6 +293,164 @@ class DistillReport:
     superseded: int = 0
     conflicts: int = 0
     stale: int = 0
+    queued_conflicts: int = 0
+    conflict_case_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ConflictCandidate:
+    """One human-reviewable value backed by immutable fact IDs."""
+
+    candidate_id: str
+    kind: str
+    content: str
+    evidence_ids: tuple[str, ...]
+    occurrences: int
+    maximum_importance: int
+    first_seen: str
+    last_seen: str
+    incumbent: bool = False
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "ConflictCandidate":
+        try:
+            evidence_ids = tuple(sorted(str(item) for item in payload["evidence_ids"]))
+            incumbent = payload.get("incumbent", False)
+            if not isinstance(incumbent, bool):
+                raise ValueError("incumbent must be boolean")
+            candidate = cls(
+                candidate_id=_clean_event_id(
+                    payload["candidate_id"], field_name="conflict candidate_id"
+                ),
+                kind=str(payload["kind"]),
+                content=str(payload["content"]),
+                evidence_ids=evidence_ids,
+                occurrences=int(payload["occurrences"]),
+                maximum_importance=int(payload["maximum_importance"]),
+                first_seen=str(payload["first_seen"]),
+                last_seen=str(payload["last_seen"]),
+                incumbent=incumbent,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise MemoryCorruptionError(f"invalid conflict candidate: {exc}") from exc
+        _validate_conflict_candidate(candidate)
+        return candidate
+
+
+@dataclass
+class MemoryConflictCase:
+    """A versioned evidence snapshot that requires an explicit human choice."""
+
+    conflict_id: str
+    workspace_id: str
+    memory_key: str
+    revision: int
+    fingerprint: str
+    status: str
+    candidates: tuple[ConflictCandidate, ...]
+    observed_fact_ids: tuple[str, ...]
+    active_entry_key: str | None
+    detected_at: str
+    resolved_at: str | None = None
+    selected_candidate_id: str | None = None
+    resolution_event_id: str | None = None
+    resolution_actor: str | None = None
+    resolution_rationale: str | None = None
+    resulting_active_entry_key: str | None = None
+    superseded_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "MemoryConflictCase":
+        try:
+            case = cls(
+                conflict_id=_clean_event_id(
+                    payload["conflict_id"], field_name="conflict_id"
+                ),
+                workspace_id=str(payload["workspace_id"]),
+                memory_key=_clean_memory_key(str(payload["memory_key"])),
+                revision=int(payload["revision"]),
+                fingerprint=str(payload["fingerprint"]),
+                status=str(payload["status"]),
+                candidates=tuple(
+                    ConflictCandidate.from_dict(dict(item))
+                    for item in payload["candidates"]
+                ),
+                observed_fact_ids=tuple(
+                    sorted(str(item) for item in payload["observed_fact_ids"])
+                ),
+                active_entry_key=_optional_text(payload.get("active_entry_key")),
+                detected_at=str(payload["detected_at"]),
+                resolved_at=_optional_text(payload.get("resolved_at")),
+                selected_candidate_id=_optional_text(
+                    payload.get("selected_candidate_id")
+                ),
+                resolution_event_id=_optional_text(
+                    payload.get("resolution_event_id")
+                ),
+                resolution_actor=_optional_text(payload.get("resolution_actor")),
+                resolution_rationale=_optional_text(
+                    payload.get("resolution_rationale")
+                ),
+                resulting_active_entry_key=_optional_text(
+                    payload.get("resulting_active_entry_key")
+                ),
+                superseded_at=_optional_text(payload.get("superseded_at")),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise MemoryCorruptionError(f"invalid conflict case: {exc}") from exc
+        _validate_conflict_case(case)
+        return case
+
+
+@dataclass(frozen=True)
+class ConflictAdjudication:
+    """Append-only record proving who selected which evidence snapshot."""
+
+    event_id: str
+    workspace_id: str
+    conflict_id: str
+    case_revision: int
+    selected_candidate_id: str
+    actor: str
+    rationale: str
+    resolved_at: str
+    prior_active_entry_key: str | None
+    resulting_active_entry_key: str | None
+    evidence_ids: tuple[str, ...]
+    schema_version: int = ADJUDICATION_SCHEMA_VERSION
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "ConflictAdjudication":
+        try:
+            event = cls(
+                event_id=_clean_event_id(payload["event_id"], field_name="event_id"),
+                workspace_id=str(payload["workspace_id"]),
+                conflict_id=_clean_event_id(
+                    payload["conflict_id"], field_name="conflict_id"
+                ),
+                case_revision=int(payload["case_revision"]),
+                selected_candidate_id=_clean_event_id(
+                    payload["selected_candidate_id"],
+                    field_name="selected_candidate_id",
+                ),
+                actor=_clean_adjudication_text(payload["actor"], field_name="actor"),
+                rationale=_clean_adjudication_text(
+                    payload["rationale"], field_name="rationale"
+                ),
+                resolved_at=str(payload["resolved_at"]),
+                prior_active_entry_key=_optional_text(
+                    payload.get("prior_active_entry_key")
+                ),
+                resulting_active_entry_key=_optional_text(
+                    payload.get("resulting_active_entry_key")
+                ),
+                evidence_ids=tuple(sorted(str(item) for item in payload["evidence_ids"])),
+                schema_version=int(payload.get("schema_version", 0)),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise MemoryCorruptionError(f"invalid conflict adjudication: {exc}") from exc
+        _validate_adjudication(event)
+        return event
 
 
 def _as_utc(value: datetime | None) -> datetime:
@@ -278,6 +458,10 @@ def _as_utc(value: datetime | None) -> datetime:
     if current.tzinfo is None:
         current = current.replace(tzinfo=timezone.utc)
     return current.astimezone(timezone.utc)
+
+
+def _iso(value: datetime | None = None) -> str:
+    return _as_utc(value).isoformat().replace("+00:00", "Z")
 
 
 def _parse_timestamp(value: str) -> datetime:
@@ -307,6 +491,176 @@ def _clean_memory_key(value: str) -> str:
             "memory_key must use lowercase words separated by '.', '_' or '-'"
         )
     return key
+
+
+def _optional_text(value: object) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _clean_event_id(value: object, *, field_name: str) -> str:
+    identifier = str(value).strip()
+    if not identifier:
+        raise ValueError(f"{field_name} must not be empty")
+    if len(identifier) > MAX_EVENT_ID_CHARS or not EVENT_ID_PATTERN.fullmatch(identifier):
+        raise ValueError(
+            f"{field_name} must start with an alphanumeric character and use only "
+            "letters, digits, '.', '_', ':', '/', or '-'"
+        )
+    return identifier
+
+
+def _clean_adjudication_text(value: object, *, field_name: str) -> str:
+    text = re.sub(r"\s+", " ", str(value)).strip()
+    if not text:
+        raise ValueError(f"{field_name} must not be empty")
+    if len(text) > MAX_ADJUDICATION_TEXT_CHARS:
+        raise ValueError(
+            f"{field_name} exceeds {MAX_ADJUDICATION_TEXT_CHARS} characters"
+        )
+    return text
+
+
+def _validate_conflict_candidate(candidate: ConflictCandidate) -> None:
+    if candidate.kind not in {item.value for item in FactKind}:
+        raise MemoryCorruptionError(
+            f"conflict candidate {candidate.candidate_id} has unknown kind"
+        )
+    if not _normal_form(candidate.content):
+        raise MemoryCorruptionError(
+            f"conflict candidate {candidate.candidate_id} has empty content"
+        )
+    if len(candidate.content) > MAX_FACT_CHARS:
+        raise MemoryCorruptionError(
+            f"conflict candidate {candidate.candidate_id} content is too long"
+        )
+    if not candidate.evidence_ids or len(set(candidate.evidence_ids)) != len(
+        candidate.evidence_ids
+    ):
+        raise MemoryCorruptionError(
+            f"conflict candidate {candidate.candidate_id} needs unique evidence"
+        )
+    if candidate.occurrences != len(candidate.evidence_ids):
+        raise MemoryCorruptionError(
+            f"conflict candidate {candidate.candidate_id} has inconsistent occurrences"
+        )
+    if not 1 <= candidate.maximum_importance <= 5:
+        raise MemoryCorruptionError(
+            f"conflict candidate {candidate.candidate_id} has invalid importance"
+        )
+    first = _parse_timestamp(candidate.first_seen)
+    last = _parse_timestamp(candidate.last_seen)
+    if last < first:
+        raise MemoryCorruptionError(
+            f"conflict candidate {candidate.candidate_id} has reversed timestamps"
+        )
+
+
+def _validate_conflict_case(case: MemoryConflictCase) -> None:
+    if case.revision < 1:
+        raise MemoryCorruptionError("conflict revision must be >= 1")
+    if not re.fullmatch(r"[0-9a-f]{64}", case.fingerprint):
+        raise MemoryCorruptionError("conflict fingerprint must be a SHA-256 digest")
+    if case.status not in {item.value for item in ConflictStatus}:
+        raise MemoryCorruptionError(f"unsupported conflict status: {case.status}")
+    if len(case.candidates) < 2:
+        raise MemoryCorruptionError("conflict case needs at least two candidates")
+    candidate_ids = [candidate.candidate_id for candidate in case.candidates]
+    if candidate_ids != sorted(candidate_ids) or len(set(candidate_ids)) != len(
+        candidate_ids
+    ):
+        raise MemoryCorruptionError("conflict candidate IDs must be unique and sorted")
+    for candidate in case.candidates:
+        expected_candidate_id = _conflict_candidate_id(
+            case.memory_key, candidate.kind, candidate.content
+        )
+        if candidate.candidate_id != expected_candidate_id:
+            raise MemoryCorruptionError(
+                f"conflict candidate {candidate.candidate_id} has inconsistent identity"
+            )
+    incumbents = [candidate for candidate in case.candidates if candidate.incumbent]
+    if len(incumbents) > 1:
+        raise MemoryCorruptionError("conflict case cannot have multiple incumbents")
+    if bool(incumbents) != bool(case.active_entry_key):
+        raise MemoryCorruptionError(
+            "conflict incumbent must match the active curated entry snapshot"
+        )
+    if not case.observed_fact_ids or len(set(case.observed_fact_ids)) != len(
+        case.observed_fact_ids
+    ):
+        raise MemoryCorruptionError("conflict observed fact IDs must be unique")
+    observed = set(case.observed_fact_ids)
+    if any(not set(candidate.evidence_ids) <= observed for candidate in case.candidates):
+        raise MemoryCorruptionError("conflict candidate evidence was not observed")
+    _parse_timestamp(case.detected_at)
+
+    resolution_fields = (
+        case.resolved_at,
+        case.selected_candidate_id,
+        case.resolution_event_id,
+        case.resolution_actor,
+        case.resolution_rationale,
+        case.resulting_active_entry_key,
+    )
+    if case.status == ConflictStatus.OPEN.value:
+        if any(value is not None for value in resolution_fields) or case.superseded_at:
+            raise MemoryCorruptionError("open conflict cannot contain closure fields")
+    elif case.status == ConflictStatus.RESOLVED.value:
+        if any(value is None for value in resolution_fields) or case.superseded_at:
+            raise MemoryCorruptionError("resolved conflict needs complete resolution fields")
+        if case.selected_candidate_id not in candidate_ids:
+            raise MemoryCorruptionError("resolved conflict selected an unknown candidate")
+        _clean_event_id(case.resolution_event_id, field_name="resolution_event_id")
+        _clean_adjudication_text(case.resolution_actor, field_name="resolution_actor")
+        _clean_adjudication_text(
+            case.resolution_rationale, field_name="resolution_rationale"
+        )
+        _parse_timestamp(str(case.resolved_at))
+    else:
+        if not case.superseded_at or any(value is not None for value in resolution_fields):
+            raise MemoryCorruptionError(
+                "superseded conflict needs superseded_at and no resolution fields"
+            )
+        _parse_timestamp(case.superseded_at)
+
+    expected_fingerprint = _conflict_fingerprint(
+        memory_key=case.memory_key,
+        active_entry_key=case.active_entry_key,
+        candidates=case.candidates,
+        observed_fact_ids=case.observed_fact_ids,
+    )
+    if case.fingerprint != expected_fingerprint:
+        raise MemoryCorruptionError(
+            "conflict fingerprint does not match its evidence snapshot"
+        )
+    expected_id = _conflict_id(case.workspace_id, case.memory_key, case.fingerprint)
+    if case.conflict_id != expected_id:
+        raise MemoryCorruptionError("conflict ID does not match its evidence fingerprint")
+
+
+def _validate_adjudication(event: ConflictAdjudication) -> None:
+    if event.schema_version != ADJUDICATION_SCHEMA_VERSION:
+        raise MemoryCorruptionError("unsupported conflict adjudication schema")
+    if event.case_revision < 1:
+        raise MemoryCorruptionError("adjudication case_revision must be >= 1")
+    if not event.evidence_ids or len(set(event.evidence_ids)) != len(
+        event.evidence_ids
+    ):
+        raise MemoryCorruptionError("adjudication evidence IDs must be unique")
+    _parse_timestamp(event.resolved_at)
+
+
+def _conflict_candidate_id(memory_key: str, kind: str, content: str) -> str:
+    material = f"{memory_key}\0{kind}\0{_normal_form(content)}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"candidate-{digest}"
+
+
+def _conflict_id(workspace_id: str, memory_key: str, fingerprint: str) -> str:
+    material = f"{workspace_id}\0{memory_key}\0{fingerprint}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"conflict-{digest}"
 
 
 def _entry_key(
@@ -339,6 +693,74 @@ def _proposal_score(facts: list[MemoryFact]) -> tuple[int, int, datetime]:
     )
 
 
+def _candidate_from_facts(memory_key: str, facts: list[MemoryFact]) -> ConflictCandidate:
+    representative = max(
+        facts,
+        key=lambda fact: (
+            fact.importance,
+            _parse_timestamp(fact.recorded_at),
+            fact.fact_id,
+        ),
+    )
+    timestamps = sorted(fact.recorded_at for fact in facts)
+    evidence_ids = tuple(sorted({fact.fact_id for fact in facts}))
+    return ConflictCandidate(
+        candidate_id=_conflict_candidate_id(
+            memory_key, representative.kind, representative.content
+        ),
+        kind=representative.kind,
+        content=representative.content,
+        evidence_ids=evidence_ids,
+        occurrences=len(evidence_ids),
+        maximum_importance=max(fact.importance for fact in facts),
+        first_seen=timestamps[0],
+        last_seen=timestamps[-1],
+    )
+
+
+def _candidate_from_entry(
+    memory_key: str,
+    entry: CuratedMemoryEntry,
+    facts_by_id: Mapping[str, MemoryFact],
+) -> ConflictCandidate:
+    importance = max(
+        (facts_by_id[fact_id].importance for fact_id in entry.evidence_ids if fact_id in facts_by_id),
+        default=1,
+    )
+    return ConflictCandidate(
+        candidate_id=_conflict_candidate_id(memory_key, entry.kind, entry.content),
+        kind=entry.kind,
+        content=entry.content,
+        evidence_ids=tuple(sorted(entry.evidence_ids)),
+        occurrences=entry.occurrences,
+        maximum_importance=importance,
+        first_seen=entry.first_seen,
+        last_seen=entry.last_seen,
+        incumbent=True,
+    )
+
+
+def _conflict_fingerprint(
+    *,
+    memory_key: str,
+    active_entry_key: str | None,
+    candidates: tuple[ConflictCandidate, ...],
+    observed_fact_ids: tuple[str, ...],
+) -> str:
+    material = json.dumps(
+        {
+            "memory_key": memory_key,
+            "active_entry_key": active_entry_key,
+            "candidates": [asdict(candidate) for candidate in candidates],
+            "observed_fact_ids": observed_fact_ids,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
 class WorkspaceMemory:
     """Durable project memory with an append log and a derived compact view.
 
@@ -347,6 +769,8 @@ class WorkspaceMemory:
         .learn_workbuddy/memory/
         ├── daily/YYYY-MM-DD.jsonl   # immutable source facts
         ├── curated.json             # canonical compact state
+        ├── conflicts.json           # reviewable conflict snapshots
+        ├── conflict-adjudications.jsonl  # append-only human decisions
         └── MEMORY.md                # human/prompt-facing derived view
 
     The teaching namespace deliberately avoids writing into a real product's
@@ -364,6 +788,8 @@ class WorkspaceMemory:
         self.daily_dir = self.memory_dir / "daily"
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.curated_file = self.memory_dir / "curated.json"
+        self.conflict_file = self.memory_dir / "conflicts.json"
+        self.adjudication_file = self.memory_dir / "conflict-adjudications.jsonl"
         self.daily_dir.mkdir(parents=True, exist_ok=True)
 
     def daily_log_path(self, day: date) -> Path:
@@ -499,6 +925,402 @@ class WorkspaceMemory:
             _fsync_directory(path.parent)
         finally:
             temporary.unlink(missing_ok=True)
+
+    def _load_conflicts(self) -> list[MemoryConflictCase]:
+        if not self.conflict_file.exists():
+            return []
+        try:
+            payload = json.loads(self.conflict_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise MemoryCorruptionError("conflicts.json is not valid JSON") from exc
+        if payload.get("workspace_id") != self.workspace_id:
+            raise MemoryScopeError("conflict queue belongs to another workspace")
+        if payload.get("schema_version") != CONFLICT_SCHEMA_VERSION:
+            raise MemoryCorruptionError("unsupported conflict queue schema")
+        cases = [
+            MemoryConflictCase.from_dict(dict(item))
+            for item in payload.get("cases", [])
+        ]
+        by_id = {case.conflict_id: case for case in cases}
+        if len(by_id) != len(cases):
+            raise MemoryCorruptionError("conflict IDs must be unique")
+        revisions: set[tuple[str, int]] = set()
+        open_keys: set[str] = set()
+        for case in cases:
+            if case.workspace_id != self.workspace_id:
+                raise MemoryScopeError(
+                    f"conflict {case.conflict_id} belongs to another workspace"
+                )
+            revision_key = (case.memory_key, case.revision)
+            if revision_key in revisions:
+                raise MemoryCorruptionError(
+                    f"duplicate conflict revision for {case.memory_key}"
+                )
+            revisions.add(revision_key)
+            if case.status == ConflictStatus.OPEN.value:
+                if case.memory_key in open_keys:
+                    raise MemoryCorruptionError(
+                        f"multiple open conflicts for {case.memory_key}"
+                    )
+                open_keys.add(case.memory_key)
+        return sorted(cases, key=lambda item: (item.memory_key, item.revision))
+
+    def _save_conflicts(self, cases: list[MemoryConflictCase]) -> None:
+        # Reuse the loader's invariants before replacing the canonical snapshot.
+        ids = {case.conflict_id for case in cases}
+        if len(ids) != len(cases):
+            raise MemoryCorruptionError("conflict IDs must be unique")
+        for case in cases:
+            if case.workspace_id != self.workspace_id:
+                raise MemoryScopeError("cannot save a conflict from another workspace")
+            _validate_conflict_case(case)
+        revisions = [(case.memory_key, case.revision) for case in cases]
+        if len(revisions) != len(set(revisions)):
+            raise MemoryCorruptionError("conflict revisions must be unique per memory_key")
+        open_keys = [
+            case.memory_key
+            for case in cases
+            if case.status == ConflictStatus.OPEN.value
+        ]
+        if len(open_keys) != len(set(open_keys)):
+            raise MemoryCorruptionError("only one open conflict is allowed per memory_key")
+        payload = {
+            "schema_version": CONFLICT_SCHEMA_VERSION,
+            "workspace_id": self.workspace_id,
+            "cases": [
+                asdict(case)
+                for case in sorted(
+                    cases, key=lambda item: (item.memory_key, item.revision)
+                )
+            ],
+        }
+        self._atomic_write_text(
+            self.conflict_file,
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        )
+
+    def list_conflicts(
+        self,
+        *,
+        status: str | ConflictStatus | None = ConflictStatus.OPEN,
+    ) -> list[MemoryConflictCase]:
+        """Return deterministic review snapshots without exposing them to Prompt."""
+
+        if status is None:
+            expected = None
+        else:
+            try:
+                expected = (
+                    status if isinstance(status, ConflictStatus) else ConflictStatus(status)
+                ).value
+            except ValueError as exc:
+                raise ValueError(f"unsupported conflict status: {status}") from exc
+        return [
+            case
+            for case in self._load_conflicts()
+            if expected is None or case.status == expected
+        ]
+
+    def _read_adjudications(self) -> list[ConflictAdjudication]:
+        if not self.adjudication_file.exists():
+            return []
+        lines = self.adjudication_file.read_text(encoding="utf-8").splitlines(
+            keepends=True
+        )
+        events: list[ConflictAdjudication] = []
+        for index, line in enumerate(lines, start=1):
+            if not line.endswith("\n") and index == len(lines):
+                break
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise MemoryCorruptionError(
+                    f"invalid adjudication JSON at line {index}"
+                ) from exc
+            event = ConflictAdjudication.from_dict(payload)
+            if event.workspace_id != self.workspace_id:
+                raise MemoryScopeError(
+                    f"adjudication {event.event_id} belongs to another workspace"
+                )
+            events.append(event)
+        if len({event.event_id for event in events}) != len(events):
+            raise MemoryCorruptionError("adjudication event IDs must be unique")
+        return events
+
+    def list_adjudications(self) -> list[ConflictAdjudication]:
+        return self._read_adjudications()
+
+    def _append_adjudication(self, event: ConflictAdjudication) -> None:
+        _validate_adjudication(event)
+        if event.workspace_id != self.workspace_id:
+            raise MemoryScopeError("cannot append an adjudication for another workspace")
+        encoded = (
+            json.dumps(asdict(event), ensure_ascii=False, sort_keys=True) + "\n"
+        ).encode("utf-8")
+        descriptor = os.open(
+            self.adjudication_file,
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            written = os.write(descriptor, encoded)
+            if written != len(encoded):
+                raise OSError(
+                    f"short adjudication write: {written}/{len(encoded)} bytes"
+                )
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _queue_conflict(
+        self,
+        *,
+        memory_key: str,
+        current: CuratedMemoryEntry | None,
+        winner_facts: list[list[MemoryFact]],
+        all_keyed_facts: list[MemoryFact],
+        facts_by_id: Mapping[str, MemoryFact],
+        cases: list[MemoryConflictCase],
+        detected_at: datetime,
+    ) -> tuple[MemoryConflictCase, bool]:
+        candidates = [
+            _candidate_from_facts(memory_key, facts) for facts in winner_facts
+        ]
+        if current is not None:
+            candidates.append(
+                _candidate_from_entry(memory_key, current, facts_by_id)
+            )
+        ordered = tuple(sorted(candidates, key=lambda item: item.candidate_id))
+        observed_fact_ids = tuple(
+            sorted(
+                {fact.fact_id for fact in all_keyed_facts}
+                | {
+                    evidence_id
+                    for candidate in ordered
+                    for evidence_id in candidate.evidence_ids
+                }
+            )
+        )
+        fingerprint = _conflict_fingerprint(
+            memory_key=memory_key,
+            active_entry_key=None if current is None else current.key,
+            candidates=ordered,
+            observed_fact_ids=observed_fact_ids,
+        )
+        conflict_id = _conflict_id(self.workspace_id, memory_key, fingerprint)
+        existing = next(
+            (case for case in cases if case.conflict_id == conflict_id), None
+        )
+        if existing is not None:
+            return existing, False
+
+        timestamp = _iso(detected_at)
+        for case in cases:
+            if (
+                case.memory_key == memory_key
+                and case.status == ConflictStatus.OPEN.value
+            ):
+                case.status = ConflictStatus.SUPERSEDED.value
+                case.superseded_at = timestamp
+        revision = 1 + max(
+            (case.revision for case in cases if case.memory_key == memory_key),
+            default=0,
+        )
+        case = MemoryConflictCase(
+            conflict_id=conflict_id,
+            workspace_id=self.workspace_id,
+            memory_key=memory_key,
+            revision=revision,
+            fingerprint=fingerprint,
+            status=ConflictStatus.OPEN.value,
+            candidates=ordered,
+            observed_fact_ids=observed_fact_ids,
+            active_entry_key=None if current is None else current.key,
+            detected_at=timestamp,
+        )
+        _validate_conflict_case(case)
+        cases.append(case)
+        return case, True
+
+    @staticmethod
+    def _resolved_case_for(
+        cases: list[MemoryConflictCase],
+        memory_key: str,
+        active_entry_key: str | None,
+    ) -> MemoryConflictCase | None:
+        matching = [
+            case
+            for case in cases
+            if case.memory_key == memory_key
+            and case.status == ConflictStatus.RESOLVED.value
+            and case.resulting_active_entry_key == active_entry_key
+        ]
+        return max(matching, key=lambda item: item.revision, default=None)
+
+    def resolve_conflict(
+        self,
+        conflict_id: str,
+        selected_candidate_id: str,
+        *,
+        expected_revision: int,
+        actor: str,
+        rationale: str,
+        event_id: str,
+        resolved_at: datetime | None = None,
+    ) -> ConflictAdjudication:
+        """Apply one explicit choice while retaining all losing evidence."""
+
+        clean_conflict_id = _clean_event_id(conflict_id, field_name="conflict_id")
+        clean_candidate_id = _clean_event_id(
+            selected_candidate_id, field_name="selected_candidate_id"
+        )
+        clean_event_id = _clean_event_id(event_id, field_name="event_id")
+        clean_actor = _clean_adjudication_text(actor, field_name="actor")
+        clean_rationale = _clean_adjudication_text(
+            rationale, field_name="rationale"
+        )
+        if isinstance(expected_revision, bool) or not isinstance(expected_revision, int):
+            raise TypeError("expected_revision must be an integer")
+        if expected_revision < 1:
+            raise ValueError("expected_revision must be >= 1")
+
+        existing_events = self._read_adjudications()
+        duplicate = next(
+            (event for event in existing_events if event.event_id == clean_event_id),
+            None,
+        )
+        if duplicate is not None:
+            if (
+                duplicate.conflict_id == clean_conflict_id
+                and duplicate.case_revision == expected_revision
+                and duplicate.selected_candidate_id == clean_candidate_id
+                and duplicate.actor == clean_actor
+                and duplicate.rationale == clean_rationale
+            ):
+                return duplicate
+            raise ConflictResolutionError(
+                f"adjudication event {clean_event_id} was already used differently"
+            )
+
+        cases = self._load_conflicts()
+        case = next(
+            (item for item in cases if item.conflict_id == clean_conflict_id),
+            None,
+        )
+        if case is None:
+            raise ConflictResolutionError(f"unknown conflict: {clean_conflict_id}")
+        if case.revision != expected_revision:
+            raise StaleConflictResolutionError(
+                f"conflict revision changed from {expected_revision} to {case.revision}"
+            )
+        if case.status != ConflictStatus.OPEN.value:
+            raise StaleConflictResolutionError(
+                f"conflict {clean_conflict_id} is {case.status}, not open"
+            )
+        selected = next(
+            (
+                candidate
+                for candidate in case.candidates
+                if candidate.candidate_id == clean_candidate_id
+            ),
+            None,
+        )
+        if selected is None:
+            raise ConflictResolutionError(
+                f"candidate {clean_candidate_id} is not part of {clean_conflict_id}"
+            )
+
+        facts = self.read_all_facts()
+        entries = self._load_curated()
+        current = next(
+            (
+                entry
+                for entry in entries
+                if entry.memory_key == case.memory_key
+                and entry.status == CuratedStatus.ACTIVE.value
+            ),
+            None,
+        )
+        current_key = None if current is None else current.key
+        if current_key != case.active_entry_key:
+            raise StaleConflictResolutionError(
+                "active curated memory changed after this conflict was detected"
+            )
+        current_observed = tuple(
+            sorted(
+                {
+                    fact.fact_id
+                    for fact in facts
+                    if fact.memory_key == case.memory_key
+                }
+                | (set() if current is None else set(current.evidence_ids))
+            )
+        )
+        if current_observed != case.observed_fact_ids:
+            raise StaleConflictResolutionError(
+                "workspace evidence changed after this conflict was detected"
+            )
+
+        if selected.incumbent:
+            if current is None:
+                raise MemoryCorruptionError("conflict incumbent is no longer active")
+            resulting_key = current.key
+        else:
+            revision = 1 if current is None else current.revision + 1
+            resulting_key = _entry_key(
+                selected.kind,
+                selected.content,
+                memory_key=case.memory_key,
+                revision=revision,
+            )
+            if any(entry.key == resulting_key for entry in entries):
+                raise MemoryCorruptionError(
+                    f"curated revision key collision for {case.memory_key}"
+                )
+            new_entry = CuratedMemoryEntry(
+                key=resulting_key,
+                kind=selected.kind,
+                content=selected.content,
+                first_seen=selected.first_seen,
+                last_seen=selected.last_seen,
+                evidence_ids=list(selected.evidence_ids),
+                occurrences=selected.occurrences,
+                memory_key=case.memory_key,
+                revision=revision,
+                status=CuratedStatus.ACTIVE.value,
+                supersedes=None if current is None else current.key,
+            )
+            if current is not None:
+                current.status = CuratedStatus.SUPERSEDED.value
+                current.superseded_by = new_entry.key
+            entries.append(new_entry)
+            self._save_curated(entries)
+
+        timestamp = _iso(resolved_at)
+        case.status = ConflictStatus.RESOLVED.value
+        case.resolved_at = timestamp
+        case.selected_candidate_id = selected.candidate_id
+        case.resolution_event_id = clean_event_id
+        case.resolution_actor = clean_actor
+        case.resolution_rationale = clean_rationale
+        case.resulting_active_entry_key = resulting_key
+        self._save_conflicts(cases)
+
+        event = ConflictAdjudication(
+            event_id=clean_event_id,
+            workspace_id=self.workspace_id,
+            conflict_id=case.conflict_id,
+            case_revision=case.revision,
+            selected_candidate_id=selected.candidate_id,
+            actor=clean_actor,
+            rationale=clean_rationale,
+            resolved_at=timestamp,
+            prior_active_entry_key=current_key,
+            resulting_active_entry_key=resulting_key,
+            evidence_ids=selected.evidence_ids,
+        )
+        self._append_adjudication(event)
+        return event
 
     def _load_curated(self) -> list[CuratedMemoryEntry]:
         if not self.curated_file.exists():
@@ -686,16 +1508,20 @@ class WorkspaceMemory:
         """
 
         active_policy = policy or DistillPolicy()
-        cutoff = _as_utc(as_of) - timedelta(days=active_policy.minimum_age_days)
+        observed_at = _as_utc(as_of)
+        cutoff = observed_at - timedelta(days=active_policy.minimum_age_days)
         existing = self._load_curated()
+        conflict_cases = self._load_conflicts()
         by_key = {entry.key: entry for entry in existing}
         processed_ids = {
             evidence_id for entry in existing for evidence_id in entry.evidence_ids
         }
 
+        all_facts = self.read_all_facts()
+        facts_by_id = {fact.fact_id: fact for fact in all_facts}
         aged = [
             fact
-            for fact in self.read_all_facts()
+            for fact in all_facts
             if _parse_timestamp(fact.recorded_at) < cutoff
         ]
         candidates = [
@@ -711,7 +1537,11 @@ class WorkspaceMemory:
         superseded = 0
         conflicts = 0
         stale = 0
+        queued_conflicts = 0
+        conflict_case_ids: list[str] = []
+        conflicted_memory_keys: set[str] = set()
         changed = False
+        conflicts_changed = False
 
         def distinct(facts: list[MemoryFact]) -> list[MemoryFact]:
             return list({fact.fact_id: fact for fact in facts}.values())
@@ -822,8 +1652,34 @@ class WorkspaceMemory:
                     updated += 1
                     changed = True
 
+            resolved_case = self._resolved_case_for(
+                conflict_cases,
+                memory_key,
+                None if current is None else current.key,
+            )
+
             qualified: list[tuple[tuple[str, str], list[MemoryFact]]] = []
             for signature, facts in proposals.items():
+                if resolved_case is not None:
+                    candidate_id = _conflict_candidate_id(
+                        memory_key, signature[0], facts[0].content
+                    )
+                    reviewed = next(
+                        (
+                            candidate
+                            for candidate in resolved_case.candidates
+                            if candidate.candidate_id == candidate_id
+                        ),
+                        None,
+                    )
+                    if (
+                        reviewed is not None
+                        and candidate_id != resolved_case.selected_candidate_id
+                        and tuple(sorted(fact.fact_id for fact in facts))
+                        == reviewed.evidence_ids
+                    ):
+                        skipped += len(facts)
+                        continue
                 if not qualifies(facts):
                     skipped += len(facts)
                     continue
@@ -852,6 +1708,22 @@ class WorkspaceMemory:
             if len(winners) != 1:
                 conflicts += 1
                 skipped += sum(len(facts) for _signature, facts in qualified)
+                conflicted_memory_keys.add(memory_key)
+                case, created_case = self._queue_conflict(
+                    memory_key=memory_key,
+                    current=current,
+                    winner_facts=[facts for _signature, facts in winners],
+                    all_keyed_facts=[
+                        fact for fact in all_facts if fact.memory_key == memory_key
+                    ],
+                    facts_by_id=facts_by_id,
+                    cases=conflict_cases,
+                    detected_at=observed_at,
+                )
+                conflict_case_ids.append(case.conflict_id)
+                if created_case:
+                    queued_conflicts += 1
+                    conflicts_changed = True
                 continue
 
             winning_signature, winning_facts = winners[0]
@@ -897,8 +1769,21 @@ class WorkspaceMemory:
             created += 1
             changed = True
 
+        closed_at = _iso(observed_at)
+        for case in conflict_cases:
+            if (
+                case.status == ConflictStatus.OPEN.value
+                and case.memory_key in keyed_groups
+                and case.memory_key not in conflicted_memory_keys
+            ):
+                case.status = ConflictStatus.SUPERSEDED.value
+                case.superseded_at = closed_at
+                conflicts_changed = True
+
         if changed:
             self._save_curated(list(by_key.values()))
+        if conflicts_changed:
+            self._save_conflicts(conflict_cases)
 
         return DistillReport(
             scanned=len(aged),
@@ -909,6 +1794,8 @@ class WorkspaceMemory:
             superseded=superseded,
             conflicts=conflicts,
             stale=stale,
+            queued_conflicts=queued_conflicts,
+            conflict_case_ids=tuple(conflict_case_ids),
         )
 
     def get_context_for_agent(self, *, recent_limit: int = MAX_CONTEXT_FACTS) -> str:
@@ -1092,8 +1979,11 @@ def _print_report(report: DistillReport) -> None:
         "distill: "
         f"scanned={report.scanned}, eligible={report.eligible}, "
         f"created={report.created}, updated={report.updated}, skipped={report.skipped}, "
-        f"superseded={report.superseded}, conflicts={report.conflicts}, stale={report.stale}"
+        f"superseded={report.superseded}, conflicts={report.conflicts}, "
+        f"queued={report.queued_conflicts}, stale={report.stale}"
     )
+    if report.conflict_case_ids:
+        print("review:  " + ", ".join(report.conflict_case_ids))
 
 
 def main() -> None:
@@ -1102,7 +1992,7 @@ def main() -> None:
     agent = MemoryAwareAgent(WORKDIR, memory)
     print(f"workspace: {memory.project_dir}")
     print(f"memory:    {memory.memory_dir}")
-    print("commands: /memory /today /logs /distill /reset q")
+    print("commands: /memory /today /logs /distill /conflicts /resolve /reset q")
 
     while True:
         try:
@@ -1131,6 +2021,48 @@ def main() -> None:
             continue
         if query == "/distill":
             _print_report(memory.distill())
+            continue
+        if query == "/conflicts":
+            cases = memory.list_conflicts()
+            for case in cases:
+                print(
+                    f"{case.conflict_id} revision={case.revision} "
+                    f"memory_key={case.memory_key}"
+                )
+                for candidate in case.candidates:
+                    marker = " (current)" if candidate.incumbent else ""
+                    print(
+                        f"  {candidate.candidate_id}{marker}: {candidate.content} "
+                        f"[{len(candidate.evidence_ids)} evidence]"
+                    )
+            if not cases:
+                print("(no open memory conflicts)")
+            continue
+        if query.startswith("/resolve "):
+            parts = query.split(maxsplit=5)
+            if len(parts) != 6:
+                print(
+                    "usage: /resolve <conflict_id> <revision> "
+                    "<candidate_id> <event_id> <rationale>"
+                )
+                continue
+            _, conflict_id, revision, candidate_id, event_id, rationale = parts
+            try:
+                event = memory.resolve_conflict(
+                    conflict_id,
+                    candidate_id,
+                    expected_revision=int(revision),
+                    actor="local-cli-user",
+                    rationale=rationale,
+                    event_id=event_id,
+                )
+            except (ValueError, MemoryErrorBase) as exc:
+                print(f"resolution rejected: {exc}")
+            else:
+                print(
+                    f"resolved {event.conflict_id} -> "
+                    f"{event.selected_candidate_id} ({event.event_id})"
+                )
             continue
         if query == "/reset":
             agent.messages.clear()

--- a/s10_workspace_memory/images/workspace-memory.svg
+++ b/s10_workspace_memory/images/workspace-memory.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 560" role="img" aria-labelledby="title desc">
-  <title id="title">工作区记忆的蒸馏、冲突处理与修订链</title>
-  <desc id="desc">原始事实追加到日志，经门槛和 memory key 冲突域处理后形成可审计修订链，只有 active 修订进入 MEMORY.md 和 prompt。</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 680" role="img" aria-labelledby="title desc">
+  <title id="title">工作区记忆的蒸馏、人工裁决与审计</title>
+  <desc id="desc">原始事实经过蒸馏策略；唯一胜出者进入策展历史，同分候选进入持久化冲突队列，经人工裁决后更新策展状态并追加审计事件。只有 active 修订进入 prompt。</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M1 1L9 5L1 9" fill="none" stroke="context-stroke" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
@@ -15,8 +15,8 @@
       .dash{fill:none;stroke:#64748b;stroke-width:1.5;stroke-dasharray:5 5;marker-end:url(#arrow)}
     </style>
   </defs>
-  <rect width="960" height="560" fill="#f8fafc"/>
-  <text class="title" x="480" y="38" text-anchor="middle">Workspace Memory：可审计的替代与冲突处理</text>
+  <rect width="960" height="680" fill="#f8fafc"/>
+  <text class="title" x="480" y="38" text-anchor="middle">Workspace Memory：可恢复的冲突裁决</text>
 
   <rect x="35" y="75" width="215" height="150" rx="12" fill="#e7f5ec" stroke="#3f9b69"/>
   <text class="heading" x="55" y="105">daily/*.jsonl</text>
@@ -48,27 +48,48 @@
   <path class="line" d="M250 150H287"/>
   <path class="line" d="M510 150H547"/>
 
-  <rect x="555" y="285" width="175" height="100" rx="12" fill="#fef3c7" stroke="#d09a13"/>
-  <text class="heading" x="642" y="317" text-anchor="middle">MEMORY.md</text>
-  <text class="body" x="642" y="343" text-anchor="middle">仅渲染 active 修订</text>
-  <text class="small" x="642" y="366" text-anchor="middle">可从 canonical state 重建</text>
+  <rect x="575" y="300" width="160" height="100" rx="12" fill="#fef3c7" stroke="#d09a13"/>
+  <text class="heading" x="655" y="332" text-anchor="middle">MEMORY.md</text>
+  <text class="body" x="655" y="358" text-anchor="middle">仅渲染 active 修订</text>
+  <text class="small" x="655" y="381" text-anchor="middle">可从 canonical state 重建</text>
 
-  <rect x="785" y="285" width="140" height="100" rx="12" fill="#eee9ff" stroke="#7764c5"/>
-  <text class="heading" x="855" y="317" text-anchor="middle">Agent prompt</text>
-  <text class="body" x="855" y="343" text-anchor="middle">有界注入</text>
-  <text class="small" x="855" y="366" text-anchor="middle">不暴露未决候选</text>
+  <rect x="785" y="300" width="140" height="100" rx="12" fill="#eee9ff" stroke="#7764c5"/>
+  <text class="heading" x="855" y="332" text-anchor="middle">Agent prompt</text>
+  <text class="body" x="855" y="358" text-anchor="middle">有界注入</text>
+  <text class="small" x="855" y="381" text-anchor="middle">不暴露未决候选</text>
 
-  <path class="line" d="M842 225V250H642V277"/>
-  <path class="line" d="M730 335H777"/>
+  <path class="line" d="M842 225V265H655V292"/>
+  <path class="line" d="M735 350H777"/>
 
-  <rect x="35" y="285" width="475" height="100" rx="12" fill="#fff" stroke="#a9b2c1" stroke-dasharray="5 4"/>
-  <text class="heading" x="55" y="315">冲突或过期候选</text>
-  <text class="body" x="55" y="342">留在原始证据中，不修改 active 修订，也不进入 prompt</text>
-  <text class="small" x="55" y="366">DistillReport：conflicts / stale / skipped</text>
-  <path class="dash" d="M402 225V277"/>
+  <rect x="35" y="285" width="260" height="130" rx="12" fill="#fff" stroke="#a9b2c1" stroke-dasharray="5 4"/>
+  <text class="heading" x="55" y="315">conflicts.json</text>
+  <text class="body" x="55" y="341">同分候选的完整证据快照</text>
+  <text class="small" x="55" y="365">revision + fingerprint</text>
+  <text class="small" x="55" y="387">open / resolved / superseded</text>
+  <path class="dash" d="M402 225V250H165V277"/>
 
-  <rect x="35" y="435" width="890" height="88" rx="12" fill="#edf2f7" stroke="#a9b2c1"/>
-  <text class="heading" x="55" y="465">不变量</text>
-  <text class="body" x="55" y="490">同一 memory_key 恰好一个 active 修订 · 修订号连续 · supersedes 链双向一致 · 原始 evidence 永不因蒸馏删除</text>
-  <text class="small" x="55" y="511">v1 状态按 legacy 语义读取，下一次成功蒸馏迁移为 v2；损坏状态显式报错。</text>
+  <rect x="335" y="285" width="190" height="130" rx="12" fill="#e9f7f6" stroke="#3c948e"/>
+  <text class="heading" x="430" y="315" text-anchor="middle">Human reviewer</text>
+  <text class="body" x="430" y="341" text-anchor="middle">expected revision</text>
+  <text class="body" x="430" y="365" text-anchor="middle">selected candidate</text>
+  <text class="small" x="430" y="389" text-anchor="middle">actor · rationale · event ID</text>
+  <path class="line" d="M295 350H327"/>
+  <path class="line" d="M430 285V250H740V233"/>
+  <text class="small" x="585" y="272" text-anchor="middle">keep incumbent / promote challenger</text>
+
+  <rect x="335" y="465" width="390" height="95" rx="12" fill="#eef2ff" stroke="#6878bd"/>
+  <text class="heading" x="355" y="495">conflict-adjudications.jsonl</text>
+  <text class="body" x="355" y="521">append-only：选择、证据、actor 与 rationale</text>
+  <text class="small" x="355" y="544">相同 event ID 重试幂等；不同载荷 fail closed</text>
+  <path class="line" d="M430 415V457"/>
+
+  <rect x="35" y="465" width="260" height="95" rx="12" fill="#fff7ed" stroke="#d28a35"/>
+  <text class="heading" x="55" y="495">陈旧裁决拒绝</text>
+  <text class="body" x="55" y="521">新增证据或 active 版本变化</text>
+  <text class="small" x="55" y="544">要求 reviewer 重新加载快照</text>
+  <path class="dash" d="M335 390H315V457"/>
+
+  <rect x="35" y="595" width="890" height="55" rx="12" fill="#edf2f7" stroke="#a9b2c1"/>
+  <text class="heading" x="55" y="620">不变量</text>
+  <text class="small" x="55" y="641">一个 memory_key 只有一个 active 修订 · 未决候选不进 prompt · 原始 evidence 与裁决事件只追加 · 损坏状态显式报错</text>
 </svg>

--- a/tests/test_workspace_memory.py
+++ b/tests/test_workspace_memory.py
@@ -68,6 +68,31 @@ def _append_pair(
         )
 
 
+def _database_conflict(s10, root: Path):
+    memory = s10.WorkspaceMemory(root)
+    memory.append_daily_log(
+        "Use SQLite.",
+        kind="decision",
+        importance=5,
+        memory_key="storage.database",
+        recorded_at=_old(1),
+        fact_id="database-current",
+    )
+    as_of = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    memory.distill(as_of=as_of)
+    for content, prefix in (("Use Postgres.", "pg"), ("Use MySQL.", "mysql")):
+        _append_pair(
+            memory,
+            content,
+            memory_key="storage.database",
+            first_day=10,
+            prefix=prefix,
+        )
+    report = memory.distill(as_of=as_of)
+    case = memory.list_conflicts()[0]
+    return memory, as_of, report, case
+
+
 def test_workspace_scope_isolated_and_log_is_append_only(s10, tmp_path: Path) -> None:
     first = s10.WorkspaceMemory(tmp_path / "project-a")
     second = s10.WorkspaceMemory(tmp_path / "project-b")
@@ -334,35 +359,291 @@ def test_stale_evidence_cannot_roll_back_active_revision(s10, tmp_path: Path) ->
 def test_equal_strength_conflict_fails_closed_and_is_observable(
     s10, tmp_path: Path
 ) -> None:
-    memory = s10.WorkspaceMemory(tmp_path / "project")
-    memory.append_daily_log(
-        "Use SQLite.",
-        kind="decision",
-        importance=5,
-        memory_key="storage.database",
-        recorded_at=_old(1),
-        fact_id="database-current",
+    memory, as_of, report, case = _database_conflict(
+        s10, tmp_path / "project"
     )
-    as_of = datetime(2026, 3, 1, tzinfo=timezone.utc)
-    memory.distill(as_of=as_of)
-    for content, prefix in (("Use Postgres.", "pg"), ("Use MySQL.", "mysql")):
-        _append_pair(
-            memory,
-            content,
-            memory_key="storage.database",
-            first_day=10,
-            prefix=prefix,
-        )
-
-    report = memory.distill(as_of=as_of)
 
     assert report.conflicts == 1
+    assert report.queued_conflicts == 1
+    assert report.conflict_case_ids == (case.conflict_id,)
     assert report.superseded == 0
     assert report.created == 0
     assert "Use SQLite." in memory.read_memory_md()
     assert "Use Postgres." not in memory.get_context_for_agent()
     assert "Use MySQL." not in memory.get_context_for_agent()
     assert len(memory._load_curated()) == 1
+    assert case.status == "open"
+    assert case.revision == 1
+    assert case.active_entry_key == memory._load_curated()[0].key
+    assert [candidate.candidate_id for candidate in case.candidates] == sorted(
+        candidate.candidate_id for candidate in case.candidates
+    )
+    assert {candidate.content for candidate in case.candidates} == {
+        "Use SQLite.",
+        "Use Postgres.",
+        "Use MySQL.",
+    }
+    assert sum(candidate.incumbent for candidate in case.candidates) == 1
+    assert set(case.observed_fact_ids) == {
+        "database-current",
+        "pg1",
+        "pg2",
+        "mysql1",
+        "mysql2",
+    }
+
+    before = memory.conflict_file.read_text(encoding="utf-8")
+    rerun = memory.distill(as_of=as_of)
+    assert rerun.conflicts == 1
+    assert rerun.queued_conflicts == 0
+    assert rerun.conflict_case_ids == (case.conflict_id,)
+    assert memory.conflict_file.read_text(encoding="utf-8") == before
+
+
+def test_human_resolution_creates_revision_and_append_only_audit(
+    s10, tmp_path: Path
+) -> None:
+    root = tmp_path / "project"
+    memory, as_of, _, case = _database_conflict(s10, root)
+    selected = next(
+        candidate for candidate in case.candidates if candidate.content == "Use Postgres."
+    )
+
+    event = memory.resolve_conflict(
+        case.conflict_id,
+        selected.candidate_id,
+        expected_revision=case.revision,
+        actor="KEDADA",
+        rationale="The deployment target requires PostgreSQL features.",
+        event_id="review:storage-database:1",
+        resolved_at=as_of,
+    )
+
+    assert event.actor == "KEDADA"
+    assert event.evidence_ids == ("pg1", "pg2")
+    assert len(memory.list_adjudications()) == 1
+    assert memory.adjudication_file.read_text(encoding="utf-8").count("\n") == 1
+    resolved = memory.list_conflicts(status=s10.ConflictStatus.RESOLVED)[0]
+    assert resolved.selected_candidate_id == selected.candidate_id
+    assert resolved.resulting_active_entry_key == event.resulting_active_entry_key
+
+    entries = sorted(memory._load_curated(), key=lambda item: item.revision)
+    assert len(entries) == 2
+    assert entries[0].status == "superseded"
+    assert entries[1].status == "active"
+    assert entries[1].content == "Use Postgres."
+    assert entries[1].supersedes == entries[0].key
+    assert entries[0].superseded_by == entries[1].key
+    assert "Use Postgres." in memory.get_context_for_agent()
+    assert "Use MySQL." not in memory.get_context_for_agent()
+    assert len(memory.read_all_facts()) == 5
+
+    # Replaying distillation cannot promote a rejected candidate from the same
+    # reviewed evidence snapshot.
+    rerun = memory.distill(as_of=as_of)
+    assert rerun.created == 0
+    assert rerun.superseded == 0
+    assert next(
+        entry for entry in memory._load_curated() if entry.status == "active"
+    ).content == "Use Postgres."
+
+    recovered = s10.WorkspaceMemory(root)
+    assert recovered.list_conflicts() == []
+    assert recovered.list_conflicts(status=None)[0].status == "resolved"
+    assert recovered.list_adjudications() == [event]
+
+
+def test_resolution_retry_is_idempotent_and_event_reuse_is_rejected(
+    s10, tmp_path: Path
+) -> None:
+    memory, as_of, _, case = _database_conflict(s10, tmp_path / "project")
+    postgres = next(
+        candidate for candidate in case.candidates if candidate.content == "Use Postgres."
+    )
+    mysql = next(
+        candidate for candidate in case.candidates if candidate.content == "Use MySQL."
+    )
+    kwargs = {
+        "expected_revision": case.revision,
+        "actor": "KEDADA",
+        "rationale": "Use the reviewed deployment standard.",
+        "event_id": "review-retry-1",
+        "resolved_at": as_of,
+    }
+
+    first = memory.resolve_conflict(
+        case.conflict_id, postgres.candidate_id, **kwargs
+    )
+    second = memory.resolve_conflict(
+        case.conflict_id, postgres.candidate_id, **kwargs
+    )
+
+    assert second == first
+    assert len(memory.list_adjudications()) == 1
+    assert len(memory._load_curated()) == 2
+    with pytest.raises(s10.ConflictResolutionError, match="already used differently"):
+        memory.resolve_conflict(case.conflict_id, mysql.candidate_id, **kwargs)
+
+
+def test_reviewer_can_keep_incumbent_without_creating_fake_revision(
+    s10, tmp_path: Path
+) -> None:
+    memory, as_of, _, case = _database_conflict(s10, tmp_path / "project")
+    incumbent = next(candidate for candidate in case.candidates if candidate.incumbent)
+
+    event = memory.resolve_conflict(
+        case.conflict_id,
+        incumbent.candidate_id,
+        expected_revision=case.revision,
+        actor="KEDADA",
+        rationale="The alternatives do not justify changing the current database.",
+        event_id="review-keep-current-1",
+        resolved_at=as_of,
+    )
+
+    assert event.prior_active_entry_key == event.resulting_active_entry_key
+    assert len(memory._load_curated()) == 1
+    memory.distill(as_of=as_of)
+    active = memory._load_curated()[0]
+    assert active.content == "Use SQLite."
+    assert active.revision == 1
+    assert "Use Postgres." not in memory.get_context_for_agent()
+
+
+def test_new_evidence_invalidates_observed_conflict_snapshot(
+    s10, tmp_path: Path
+) -> None:
+    memory, as_of, _, case = _database_conflict(s10, tmp_path / "project")
+    postgres = next(
+        candidate for candidate in case.candidates if candidate.content == "Use Postgres."
+    )
+    memory.append_daily_log(
+        "Use Postgres.",
+        kind="decision",
+        importance=4,
+        memory_key="storage.database",
+        recorded_at=_old(20),
+        fact_id="pg3",
+    )
+
+    with pytest.raises(
+        s10.StaleConflictResolutionError, match="evidence changed"
+    ):
+        memory.resolve_conflict(
+            case.conflict_id,
+            postgres.candidate_id,
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="This review is now stale.",
+            event_id="stale-review-1",
+            resolved_at=as_of,
+        )
+
+    assert memory.list_adjudications() == []
+    assert memory.list_conflicts()[0].conflict_id == case.conflict_id
+    assert memory._load_curated()[0].content == "Use SQLite."
+
+
+def test_refreshed_equal_conflict_supersedes_old_revision(
+    s10, tmp_path: Path
+) -> None:
+    memory, as_of, _, original = _database_conflict(s10, tmp_path / "project")
+    for content, fact_id in (("Use Postgres.", "pg3"), ("Use MySQL.", "mysql3")):
+        memory.append_daily_log(
+            content,
+            kind="decision",
+            importance=4,
+            memory_key="storage.database",
+            recorded_at=_old(20),
+            fact_id=fact_id,
+        )
+
+    report = memory.distill(as_of=as_of)
+    refreshed = memory.list_conflicts()[0]
+
+    assert report.queued_conflicts == 1
+    assert refreshed.revision == 2
+    assert refreshed.conflict_id != original.conflict_id
+    old = next(
+        case
+        for case in memory.list_conflicts(status=None)
+        if case.conflict_id == original.conflict_id
+    )
+    assert old.status == "superseded"
+    with pytest.raises(s10.StaleConflictResolutionError, match="not open"):
+        memory.resolve_conflict(
+            original.conflict_id,
+            original.candidates[0].candidate_id,
+            expected_revision=original.revision,
+            actor="KEDADA",
+            rationale="Old browser tab.",
+            event_id="stale-revision-1",
+            resolved_at=as_of,
+        )
+
+
+def test_conflict_queue_scope_validation_and_partial_audit_tail(
+    s10, tmp_path: Path
+) -> None:
+    first, as_of, _, case = _database_conflict(s10, tmp_path / "project-a")
+    selected = next(candidate for candidate in case.candidates if not candidate.incumbent)
+    first.resolve_conflict(
+        case.conflict_id,
+        selected.candidate_id,
+        expected_revision=case.revision,
+        actor="KEDADA",
+        rationale="Reviewed candidate.",
+        event_id="audit-tail-1",
+        resolved_at=as_of,
+    )
+    with first.adjudication_file.open("ab") as handle:
+        handle.write(b'{"event_id":')
+    assert [event.event_id for event in first.list_adjudications()] == ["audit-tail-1"]
+
+    second = s10.WorkspaceMemory(tmp_path / "project-b")
+    second.conflict_file.write_text(
+        first.conflict_file.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    with pytest.raises(s10.MemoryScopeError, match="another workspace"):
+        second.list_conflicts()
+
+
+def test_unknown_candidate_and_invalid_boundary_values_fail_closed(
+    s10, tmp_path: Path
+) -> None:
+    memory, as_of, _, case = _database_conflict(s10, tmp_path / "project")
+    with pytest.raises(s10.ConflictResolutionError, match="is not part"):
+        memory.resolve_conflict(
+            case.conflict_id,
+            "candidate-0000000000000000",
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="Unknown candidate must fail.",
+            event_id="unknown-candidate-1",
+            resolved_at=as_of,
+        )
+    with pytest.raises(ValueError, match="event_id"):
+        memory.resolve_conflict(
+            case.conflict_id,
+            case.candidates[0].candidate_id,
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="Invalid event identifier.",
+            event_id="bad event id",
+            resolved_at=as_of,
+        )
+    with pytest.raises(TypeError, match="expected_revision must be an integer"):
+        memory.resolve_conflict(
+            case.conflict_id,
+            case.candidates[0].candidate_id,
+            expected_revision=True,
+            actor="KEDADA",
+            rationale="Boolean revisions must not pass as integers.",
+            event_id="boolean-revision-1",
+            resolved_at=as_of,
+        )
+    with pytest.raises(ValueError, match="unsupported conflict status"):
+        memory.list_conflicts(status="pending")
 
 
 def test_supersession_is_idempotent_and_recovers_in_a_new_instance(


### PR DESCRIPTION
## Summary

- persist deterministic, versioned memory conflict cases for equal-strength candidates
- add explicit human adjudication with evidence/revision freshness checks and idempotent event IDs
- retain append-only adjudication audit records while keeping unresolved candidates out of agent prompts
- document the review workflow and update the S10 architecture diagram

## Verification

- `python -m pytest -q tests/test_workspace_memory.py` (20 passed)
- clean-worktree Memory/Context/chapter contract suite (88 passed)
- SVG XML parse and rendered visual inspection
- GitHub Actions is required to pass on Python 3.10, 3.11, and 3.12 before merge