### PR TITLE
feat(s10): add crash-recoverable adjudication journal

### DIFF
--- a/s10_workspace_memory/README.md
+++ b/s10_workspace_memory/README.md
@@ -20,9 +20,10 @@ flowchart LR
     H -->|"stale"| C
     H -->|"tie"| Q["conflicts.json review queue"]
     Q --> R["human resolve_conflict"]
-    R --> K["append-only adjudication audit"]
-    R -->|"challenger"| I
-    R -->|"incumbent"| J
+    R --> T["append-only transaction journal"]
+    T --> K["append-only adjudication audit"]
+    T -->|"challenger"| I
+    T -->|"incumbent"| J
     I --> J["curated.json history"]
     J --> F["active-only MEMORY.md"]
     F --> G["bounded prompt context"]
@@ -40,6 +41,7 @@ s09 的 JSONL transcript 属于某个 session，是完整执行证据；本章�
 - 被替代的修订和原始证据继续保留，prompt 只注入每个冲突域的 active 修订。
 - 同强度冲突会形成持久化 review case；只有显式的人类裁决能选择候选。
 - 裁决绑定 evidence fingerprint、case revision 和 event ID；陈旧页面或重试不会覆盖新证据。
+- 多文件裁决先写 append-only transaction intent；任意写入边界退出后都能在重启时幂等前滚。
 - 策展状态通过原子替换更新，失败时仍保留上一份完整文件。
 - 不依赖 API key 就能验证记忆策略。
 
@@ -57,6 +59,7 @@ project/
         ├── curated.json
         ├── conflicts.json
         ├── conflict-adjudications.jsonl
+        ├── conflict-resolution-transactions.jsonl
         └── MEMORY.md
 ```
 
@@ -66,6 +69,7 @@ project/
 | `curated.json` | 策展状态的机器真相 | 临时文件 + `os.replace` | 可追溯到 evidence id |
 | `conflicts.json` | 待审与历史冲突快照 | 临时文件 + `os.replace` | 是，保存候选、revision 与 fingerprint |
 | `conflict-adjudications.jsonl` | 人工裁决审计流 | `O_APPEND` 单事件追加 | 是，记录 actor、rationale 与选中证据 |
+| `conflict-resolution-transactions.jsonl` | 多文件裁决恢复日志 | `O_APPEND` 阶段事件 | 是，保存 intent hash、前后快照与提交阶段 |
 | `MEMORY.md` | 面向人和 prompt 的派生视图 | 从策展状态原子重建 | 否，随时可重建 |
 
 教学实现使用 `.learn_workbuddy` 命名空间，避免练习代码碰到真实产品状态。`WorkspaceMemory` 会先解析项目绝对路径，再生成 `workspace_id`；日志和策展文件在读取时都校验该 id。
@@ -162,7 +166,7 @@ event = memory.resolve_conflict(
 4. selected candidate 确实属于该 case；
 5. event ID 未被用于另一种裁决。
 
-任何新增证据都会触发 `StaleConflictResolutionError`，要求 reviewer 重新查看候选。选择 challenger 时创建下一版 curated revision；选择 incumbent 时只记录“保持现状”，不会制造虚假修订。成功事件追加到 `conflict-adjudications.jsonl`，包含 actor、rationale、case revision、选中 evidence IDs、原 active key 与结果 active key。
+任何新增证据都会触发 `StaleConflictResolutionError`，要求 reviewer 重新查看候选。选择 challenger 时创建下一版 curated revision；选择 incumbent 时只记录“保持现状”，不会制造虚假修订。通过校验后，Harness 会先把完整裁决 intent 写入 `conflict-resolution-transactions.jsonl`，再更新 canonical state。成功事件追加到 `conflict-adjudications.jsonl`，包含 actor、rationale、case revision、选中 evidence IDs、原 active key 与结果 active key。
 
 同一个 event ID 携带完全相同的参数重试会返回原事件，不会重复写审计或创建修订；复用 event ID 改选另一个候选会显式拒绝。裁决 API 只属于可信 Harness/人工入口，`MemoryAwareAgent` 的模型工具列表不包含它。
 
@@ -178,7 +182,7 @@ daily fact log ──select──> curated.json ──render──> MEMORY.md
 
 删除旧日志会让长期结论失去来源，也让错误蒸馏无法重新计算。真正的存储清理由单独的 retention/backup 策略负责，不和 memory distill 混在一起。
 
-### 6. 原子更新与重启恢复
+### 6. 原子更新、事务日志与重启恢复
 
 直接以 `"w"` 打开 `MEMORY.md`，进程崩溃时可能只剩半个文件。本章采用同目录临时文件：
 
@@ -189,7 +193,21 @@ daily fact log ──select──> curated.json ──render──> MEMORY.md
 
 Windows 的回退仍会在替换前完整写入、刷新并同步临时文件，再执行同目录 `os.replace`，因此不会把半个新文件暴露为 canonical state。POSIX 平台额外同步目录项，以加强断电后的 rename 持久性。
 
-`curated.json` 是 memory canonical state，`conflicts.json` 是 review queue canonical state，`MEMORY.md` 是可重建投影。如果进程在策展状态和投影两次替换之间退出，下一次读取会以 canonical state 修复陈旧投影。新建一个 `WorkspaceMemory(project_dir)` 实例即可从磁盘恢复事实、策展条目、冲突 case、裁决日志和 prompt context；不会反序列化任何进程内对象。
+单个文件的原子替换不能让三个文件共同成为原子事务。一次人工裁决需要更新 `curated.json`、关闭 `conflicts.json` case，并向 `conflict-adjudications.jsonl` 追加审计；只完成其中一部分会让项目记忆与 review/audit 状态互相矛盾。
+
+因此 `resolve_conflict()` 在产生任何业务副作用前，先把带完整 before/after 快照的 intent 追加到 transaction journal。之后依次推进：
+
+```text
+prepared
+  -> curated_applied
+  -> conflict_closed
+  -> audit_appended
+  -> committed
+```
+
+每个阶段先完成目标写入，再追加带相同 `transaction_id` 和 `intent_sha256` 的阶段事件。若进程恰好在目标写入完成、阶段事件尚未追加时退出，新的 `WorkspaceMemory(project_dir)` 会比较磁盘状态：仍等于 before 就重做，已经等于 after 就继续，既不是 before 也不是 after 则按损坏状态 fail closed。审计事件按原 event ID 去重，所以多次恢复不会创建重复修订或审计行。journal intent 被修改、阶段跳跃或 workspace 不匹配同样会显式拒绝。
+
+`curated.json` 是 memory canonical state，`conflicts.json` 是 review queue canonical state，`MEMORY.md` 是可重建投影。如果进程在策展状态和投影两次替换之间退出，恢复事务会以 canonical state 修复陈旧投影，然后继续关闭 case 和追加审计。新建一个 `WorkspaceMemory(project_dir)` 实例即可恢复未完成裁决，再加载事实、策展条目、冲突 case、裁决日志和 prompt context；不会依赖任何旧进程内对象。
 
 当前 schema 为 v2；读取器仍接受 v1 daily fact 和 curated state。旧条目按无 key 的 legacy 语义恢复，在下一次成功蒸馏写入时统一保存为 v2，而不会自动推断冲突域。读取 keyed 状态时还会校验每个域恰好一个 active 修订、修订号连续、前后链接互相匹配；损坏状态会显式报错，不会静默选择一个答案。
 
@@ -225,12 +243,14 @@ human review
   -> list open conflict snapshot
   -> submit expected revision + selected candidate + source event
   -> reject changed evidence or reused event IDs
-  -> keep incumbent or append a linked curated revision
-  -> append ConflictAdjudication JSONL event
+  -> append prepared intent with before/after snapshots
+  -> apply curated state -> close conflict -> append audit
+  -> append committed phase; retry each boundary idempotently
 
 restart
   -> resolve the same project scope
   -> validate workspace_id and schema
+  -> replay every non-committed resolution transaction
   -> reload daily facts + curated state + conflict queue + adjudication audit
   -> rebuild bounded prompt context
 ```
@@ -249,7 +269,7 @@ python3 s10_workspace_memory/code.py --demo
 python3 -m pytest -q tests/test_workspace_memory.py
 ```
 
-测试覆盖：项目隔离、追加顺序、蒸馏门槛、幂等、证据保留、原子替换失败、key 校验、新值确认、冲突 fail closed、案件去重、选择 challenger、保留 incumbent、裁决审计幂等、新证据陈旧保护、案件 revision、跨 workspace 拒绝、修订链校验、v1 迁移和跨实例恢复。
+测试覆盖：项目隔离、追加顺序、蒸馏门槛、幂等、证据保留、原子替换失败、key 校验、新值确认、冲突 fail closed、案件去重、选择 challenger、保留 incumbent、裁决审计幂等、新证据陈旧保护、案件 revision、跨 workspace 拒绝、修订链校验、v1 迁移、五阶段 transaction journal、八个持久化写入边界故障注入、投影中断修复、incumbent 恢复、intent 防篡改和重复恢复。
 
 配置模型后可运行交互路径：
 
@@ -284,11 +304,13 @@ python3 s10_workspace_memory/code.py
 - **裁决时不校验 revision/fingerprint**：旧页面可能覆盖后来到达的新事实。
 - **让模型调用 resolve 工具**：候选内容不能给自己授予裁决权限，人工入口必须位于可信 Harness 边界。
 - **选择 incumbent 也创建新修订**：这会伪造一次事实变化；保持现状只需要审计事件。
+- **把三次原子写当成一个原子事务**：每个文件都完整不代表文件之间一致；必须先持久化可重放 intent。
+- **恢复时无条件覆盖当前文件**：磁盘状态若既不等于 before 也不等于 after，可能已有更新或损坏，应 fail closed 而不是回滚证据。
 
 ## 练习
 
 1. 为 `DistillPolicy` 增加来源置信度，让用户确认的事实比工具推断更容易晋升。
-2. 把多文件裁决流程升级为带 crash recovery 的 transaction journal，验证任意写入点中断后都能安全重放。
+2. 为多进程 reviewer 增加 workspace-scoped lease，证明两个同时 prepare 的裁决不会交错写入同一个冲突域。
 3. 在不加载全部日志的前提下实现按日期倒序读取最近事实。
 
 ## 下一课

--- a/s10_workspace_memory/code.py
+++ b/s10_workspace_memory/code.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
+from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from enum import Enum
@@ -42,6 +43,7 @@ PROGRESSION = {
         "policy-driven memory distillation",
         "keyed memory supersession",
         "human conflict adjudication with append-only audit",
+        "crash-recoverable adjudication transaction journal",
         "atomic curated memory view",
     ],
     "preserves": ["append-only evidence and restart recovery"],
@@ -91,6 +93,7 @@ MEMORY_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
 EVENT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,199}$")
 CONFLICT_SCHEMA_VERSION = 1
 ADJUDICATION_SCHEMA_VERSION = 1
+RESOLUTION_TRANSACTION_SCHEMA_VERSION = 1
 WORKDIR = Path.cwd()
 _DIRECTORY_FSYNC_SUPPORTED = os.name != "nt"
 
@@ -111,6 +114,29 @@ def _fsync_directory(path: Path) -> None:
         os.fsync(directory)
     finally:
         os.close(directory)
+
+
+def _discard_incomplete_jsonl_tail(path: Path) -> None:
+    """Remove bytes that never formed a newline-terminated durable record.
+
+    Readers deliberately ignore an unterminated final line after a crash.  A
+    later append must first discard that ignored fragment, otherwise the next
+    valid JSON object would be concatenated onto it and corrupt the log.
+    """
+
+    if not path.exists() or path.stat().st_size == 0:
+        return
+    with path.open("rb+") as handle:
+        handle.seek(-1, os.SEEK_END)
+        if handle.read(1) == b"\n":
+            return
+        handle.seek(0)
+        content = handle.read()
+        last_newline = content.rfind(b"\n")
+        handle.seek(0)
+        handle.truncate(last_newline + 1)
+        handle.flush()
+        os.fsync(handle.fileno())
 
 
 class MemoryErrorBase(RuntimeError):
@@ -160,6 +186,16 @@ class ConflictStatus(str, Enum):
     OPEN = "open"
     RESOLVED = "resolved"
     SUPERSEDED = "superseded"
+
+
+class ResolutionPhase(str, Enum):
+    """Durable milestones for one multi-file human adjudication."""
+
+    PREPARED = "prepared"
+    CURATED_APPLIED = "curated_applied"
+    CONFLICT_CLOSED = "conflict_closed"
+    AUDIT_APPENDED = "audit_appended"
+    COMMITTED = "committed"
 
 
 @dataclass(frozen=True)
@@ -453,6 +489,72 @@ class ConflictAdjudication:
         return event
 
 
+@dataclass(frozen=True)
+class ConflictResolutionTransaction:
+    """Prepared before any adjudication side effect reaches canonical state.
+
+    Both before and after snapshots are intentional.  Recovery can therefore
+    distinguish "the write did not happen", "the write happened but its phase
+    marker did not", and "some unrelated state replaced the expected data".
+    The last case fails closed instead of overwriting newer or corrupt state.
+    """
+
+    transaction_id: str
+    workspace_id: str
+    conflict_id: str
+    event_id: str
+    prepared_at: str
+    curated_before: tuple[CuratedMemoryEntry, ...]
+    curated_after: tuple[CuratedMemoryEntry, ...]
+    conflicts_before: tuple[MemoryConflictCase, ...]
+    conflicts_after: tuple[MemoryConflictCase, ...]
+    adjudication: ConflictAdjudication
+    schema_version: int = RESOLUTION_TRANSACTION_SCHEMA_VERSION
+
+    @classmethod
+    def from_dict(
+        cls, payload: Mapping[str, object]
+    ) -> "ConflictResolutionTransaction":
+        try:
+            transaction = cls(
+                transaction_id=_clean_event_id(
+                    payload["transaction_id"], field_name="transaction_id"
+                ),
+                workspace_id=str(payload["workspace_id"]),
+                conflict_id=_clean_event_id(
+                    payload["conflict_id"], field_name="conflict_id"
+                ),
+                event_id=_clean_event_id(payload["event_id"], field_name="event_id"),
+                prepared_at=str(payload["prepared_at"]),
+                curated_before=tuple(
+                    CuratedMemoryEntry.from_dict(item)
+                    for item in payload["curated_before"]
+                ),
+                curated_after=tuple(
+                    CuratedMemoryEntry.from_dict(item)
+                    for item in payload["curated_after"]
+                ),
+                conflicts_before=tuple(
+                    MemoryConflictCase.from_dict(dict(item))
+                    for item in payload["conflicts_before"]
+                ),
+                conflicts_after=tuple(
+                    MemoryConflictCase.from_dict(dict(item))
+                    for item in payload["conflicts_after"]
+                ),
+                adjudication=ConflictAdjudication.from_dict(
+                    dict(payload["adjudication"])
+                ),
+                schema_version=int(payload.get("schema_version", 0)),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise MemoryCorruptionError(
+                f"invalid conflict resolution transaction: {exc}"
+            ) from exc
+        _validate_resolution_transaction(transaction)
+        return transaction
+
+
 def _as_utc(value: datetime | None) -> datetime:
     current = value or datetime.now(timezone.utc)
     if current.tzinfo is None:
@@ -651,6 +753,57 @@ def _validate_adjudication(event: ConflictAdjudication) -> None:
     _parse_timestamp(event.resolved_at)
 
 
+def _resolution_transaction_id(workspace_id: str, event_id: str) -> str:
+    material = f"{workspace_id}\0{event_id}"
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:24]
+    return f"resolution-{digest}"
+
+
+def _transaction_intent_hash(transaction: ConflictResolutionTransaction) -> str:
+    canonical = json.dumps(
+        asdict(transaction),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_resolution_transaction(
+    transaction: ConflictResolutionTransaction,
+) -> None:
+    if transaction.schema_version != RESOLUTION_TRANSACTION_SCHEMA_VERSION:
+        raise MemoryCorruptionError("unsupported resolution transaction schema")
+    expected_id = _resolution_transaction_id(
+        transaction.workspace_id, transaction.event_id
+    )
+    if transaction.transaction_id != expected_id:
+        raise MemoryCorruptionError(
+            "resolution transaction ID does not match workspace and event"
+        )
+    if transaction.conflict_id != transaction.adjudication.conflict_id:
+        raise MemoryCorruptionError(
+            "resolution transaction and adjudication conflict IDs differ"
+        )
+    if transaction.event_id != transaction.adjudication.event_id:
+        raise MemoryCorruptionError(
+            "resolution transaction and adjudication event IDs differ"
+        )
+    if transaction.workspace_id != transaction.adjudication.workspace_id:
+        raise MemoryScopeError(
+            "resolution transaction and adjudication workspaces differ"
+        )
+    _parse_timestamp(transaction.prepared_at)
+    for case in (*transaction.conflicts_before, *transaction.conflicts_after):
+        if case.workspace_id != transaction.workspace_id:
+            raise MemoryScopeError(
+                f"transaction conflict {case.conflict_id} belongs to another workspace"
+            )
+
+
+_RESOLUTION_PHASE_ORDER = tuple(phase.value for phase in ResolutionPhase)
+
+
 def _conflict_candidate_id(memory_key: str, kind: str, content: str) -> str:
     material = f"{memory_key}\0{kind}\0{_normal_form(content)}"
     digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
@@ -771,6 +924,7 @@ class WorkspaceMemory:
         ├── curated.json             # canonical compact state
         ├── conflicts.json           # reviewable conflict snapshots
         ├── conflict-adjudications.jsonl  # append-only human decisions
+        ├── conflict-resolution-transactions.jsonl  # crash recovery journal
         └── MEMORY.md                # human/prompt-facing derived view
 
     The teaching namespace deliberately avoids writing into a real product's
@@ -790,7 +944,11 @@ class WorkspaceMemory:
         self.curated_file = self.memory_dir / "curated.json"
         self.conflict_file = self.memory_dir / "conflicts.json"
         self.adjudication_file = self.memory_dir / "conflict-adjudications.jsonl"
+        self.resolution_transaction_file = (
+            self.memory_dir / "conflict-resolution-transactions.jsonl"
+        )
         self.daily_dir.mkdir(parents=True, exist_ok=True)
+        self._recover_resolution_transactions()
 
     def daily_log_path(self, day: date) -> Path:
         """Return the scoped path for one UTC day's append-only fact log."""
@@ -1057,6 +1215,7 @@ class WorkspaceMemory:
         encoded = (
             json.dumps(asdict(event), ensure_ascii=False, sort_keys=True) + "\n"
         ).encode("utf-8")
+        _discard_incomplete_jsonl_tail(self.adjudication_file)
         descriptor = os.open(
             self.adjudication_file,
             os.O_APPEND | os.O_CREAT | os.O_WRONLY,
@@ -1071,6 +1230,274 @@ class WorkspaceMemory:
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+
+    def _resolution_checkpoint(self, _name: str) -> None:
+        """Fault-injection seam used to prove recovery at durable boundaries."""
+
+    @staticmethod
+    def _curated_snapshot(entries: Iterable[CuratedMemoryEntry]) -> str:
+        ordered = sorted(
+            entries,
+            key=lambda item: (
+                item.kind,
+                item.memory_key or "",
+                item.revision,
+                item.key,
+            ),
+        )
+        return json.dumps(
+            [asdict(item) for item in ordered],
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    @staticmethod
+    def _conflict_snapshot(cases: Iterable[MemoryConflictCase]) -> str:
+        ordered = sorted(cases, key=lambda item: (item.memory_key, item.revision))
+        return json.dumps(
+            [asdict(item) for item in ordered],
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    def _append_resolution_phase(
+        self,
+        transaction: ConflictResolutionTransaction,
+        phase: ResolutionPhase,
+    ) -> None:
+        _validate_resolution_transaction(transaction)
+        if transaction.workspace_id != self.workspace_id:
+            raise MemoryScopeError(
+                "cannot append a resolution transaction for another workspace"
+            )
+        intent_hash = _transaction_intent_hash(transaction)
+        payload: dict[str, object] = {
+            "schema_version": RESOLUTION_TRANSACTION_SCHEMA_VERSION,
+            "workspace_id": self.workspace_id,
+            "transaction_id": transaction.transaction_id,
+            "phase": phase.value,
+            "recorded_at": _iso(),
+            "intent_sha256": intent_hash,
+        }
+        if phase is ResolutionPhase.PREPARED:
+            payload["intent"] = asdict(transaction)
+        encoded = (
+            json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n"
+        ).encode("utf-8")
+        _discard_incomplete_jsonl_tail(self.resolution_transaction_file)
+        descriptor = os.open(
+            self.resolution_transaction_file,
+            os.O_APPEND | os.O_CREAT | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            written = os.write(descriptor, encoded)
+            if written != len(encoded):
+                raise OSError(
+                    f"short resolution journal write: {written}/{len(encoded)} bytes"
+                )
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        self._resolution_checkpoint(f"after_{phase.value}")
+
+    def _read_resolution_transactions(
+        self,
+    ) -> list[tuple[ConflictResolutionTransaction, tuple[str, ...]]]:
+        if not self.resolution_transaction_file.exists():
+            return []
+        lines = self.resolution_transaction_file.read_text(
+            encoding="utf-8"
+        ).splitlines(keepends=True)
+        states: dict[str, dict[str, object]] = {}
+        for index, line in enumerate(lines, start=1):
+            if not line.endswith("\n") and index == len(lines):
+                break
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise MemoryCorruptionError(
+                    f"invalid resolution journal JSON at line {index}"
+                ) from exc
+            if payload.get("schema_version") != RESOLUTION_TRANSACTION_SCHEMA_VERSION:
+                raise MemoryCorruptionError(
+                    f"unsupported resolution journal schema at line {index}"
+                )
+            if payload.get("workspace_id") != self.workspace_id:
+                raise MemoryScopeError(
+                    f"resolution journal line {index} belongs to another workspace"
+                )
+            if not isinstance(payload.get("transaction_id"), str):
+                raise MemoryCorruptionError(
+                    f"invalid resolution transaction ID at line {index}"
+                )
+            transaction_id = _clean_event_id(
+                payload["transaction_id"], field_name="transaction_id"
+            )
+            try:
+                phase = ResolutionPhase(payload.get("phase"))
+            except (TypeError, ValueError) as exc:
+                raise MemoryCorruptionError(
+                    f"unsupported resolution phase at line {index}"
+                ) from exc
+            try:
+                _parse_timestamp(str(payload["recorded_at"]))
+            except KeyError as exc:
+                raise MemoryCorruptionError(
+                    f"resolution journal line {index} has no timestamp"
+                ) from exc
+            intent_hash = str(payload.get("intent_sha256", ""))
+            if not re.fullmatch(r"[0-9a-f]{64}", intent_hash):
+                raise MemoryCorruptionError(
+                    f"invalid resolution intent hash at line {index}"
+                )
+
+            state = states.get(transaction_id)
+            if phase is ResolutionPhase.PREPARED:
+                if state is not None:
+                    raise MemoryCorruptionError(
+                        f"resolution transaction {transaction_id} was prepared twice"
+                    )
+                intent = payload.get("intent")
+                if not isinstance(intent, dict):
+                    raise MemoryCorruptionError(
+                        f"prepared transaction {transaction_id} has no intent"
+                    )
+                transaction = ConflictResolutionTransaction.from_dict(intent)
+                if transaction.transaction_id != transaction_id:
+                    raise MemoryCorruptionError(
+                        "resolution journal transaction ID differs from its intent"
+                    )
+                if _transaction_intent_hash(transaction) != intent_hash:
+                    raise MemoryCorruptionError(
+                        f"resolution transaction {transaction_id} intent was modified"
+                    )
+                state = {
+                    "transaction": transaction,
+                    "intent_hash": intent_hash,
+                    "phases": [],
+                }
+                states[transaction_id] = state
+            elif state is None:
+                raise MemoryCorruptionError(
+                    f"resolution transaction {transaction_id} has no prepared intent"
+                )
+            elif state["intent_hash"] != intent_hash:
+                raise MemoryCorruptionError(
+                    f"resolution transaction {transaction_id} changed intent"
+                )
+
+            phases = state["phases"]
+            assert isinstance(phases, list)
+            phases.append(phase.value)
+
+        result: list[tuple[ConflictResolutionTransaction, tuple[str, ...]]] = []
+        for transaction_id, state in states.items():
+            phases = tuple(state["phases"])
+            expected = _RESOLUTION_PHASE_ORDER[: len(phases)]
+            if phases != expected:
+                raise MemoryCorruptionError(
+                    f"resolution transaction {transaction_id} has invalid phase order"
+                )
+            transaction = state["transaction"]
+            assert isinstance(transaction, ConflictResolutionTransaction)
+            result.append((transaction, phases))
+        return result
+
+    def _ensure_curated_transaction_state(
+        self, transaction: ConflictResolutionTransaction
+    ) -> None:
+        before = list(transaction.curated_before)
+        target = list(transaction.curated_after)
+        current = self._load_curated()
+        current_snapshot = self._curated_snapshot(current)
+        before_snapshot = self._curated_snapshot(before)
+        target_snapshot = self._curated_snapshot(target)
+        if current_snapshot == target_snapshot:
+            if self.curated_file.exists():
+                rendered = self._render_memory(target)
+                existing = (
+                    self.memory_file.read_text(encoding="utf-8")
+                    if self.memory_file.exists()
+                    else None
+                )
+                if existing != rendered:
+                    self._atomic_write_text(self.memory_file, rendered)
+                    self._resolution_checkpoint("after_memory_projection_write")
+            return
+        if current_snapshot != before_snapshot:
+            raise MemoryCorruptionError(
+                f"resolution transaction {transaction.transaction_id} found "
+                "unexpected curated state"
+            )
+        self._save_curated(target)
+        self._resolution_checkpoint("after_curated_write")
+
+    def _ensure_conflict_transaction_state(
+        self, transaction: ConflictResolutionTransaction
+    ) -> None:
+        before = list(transaction.conflicts_before)
+        target = list(transaction.conflicts_after)
+        current = self._load_conflicts()
+        current_snapshot = self._conflict_snapshot(current)
+        if current_snapshot == self._conflict_snapshot(target):
+            return
+        if current_snapshot != self._conflict_snapshot(before):
+            raise MemoryCorruptionError(
+                f"resolution transaction {transaction.transaction_id} found "
+                "unexpected conflict state"
+            )
+        self._save_conflicts(target)
+        self._resolution_checkpoint("after_conflict_write")
+
+    def _ensure_adjudication_transaction_state(
+        self, transaction: ConflictResolutionTransaction
+    ) -> None:
+        existing = next(
+            (
+                event
+                for event in self._read_adjudications()
+                if event.event_id == transaction.event_id
+            ),
+            None,
+        )
+        if existing is not None:
+            if existing != transaction.adjudication:
+                raise MemoryCorruptionError(
+                    f"resolution transaction {transaction.transaction_id} found "
+                    "a different adjudication for its event ID"
+                )
+            return
+        self._append_adjudication(transaction.adjudication)
+        self._resolution_checkpoint("after_audit_write")
+
+    def _complete_resolution_transaction(
+        self,
+        transaction: ConflictResolutionTransaction,
+        completed_phases: Iterable[str],
+    ) -> None:
+        completed = set(completed_phases)
+        self._ensure_curated_transaction_state(transaction)
+        if ResolutionPhase.CURATED_APPLIED.value not in completed:
+            self._append_resolution_phase(
+                transaction, ResolutionPhase.CURATED_APPLIED
+            )
+        self._ensure_conflict_transaction_state(transaction)
+        if ResolutionPhase.CONFLICT_CLOSED.value not in completed:
+            self._append_resolution_phase(transaction, ResolutionPhase.CONFLICT_CLOSED)
+        self._ensure_adjudication_transaction_state(transaction)
+        if ResolutionPhase.AUDIT_APPENDED.value not in completed:
+            self._append_resolution_phase(transaction, ResolutionPhase.AUDIT_APPENDED)
+        if ResolutionPhase.COMMITTED.value not in completed:
+            self._append_resolution_phase(transaction, ResolutionPhase.COMMITTED)
+
+    def _recover_resolution_transactions(self) -> None:
+        for transaction, phases in self._read_resolution_transactions():
+            if phases[-1] == ResolutionPhase.COMMITTED.value:
+                continue
+            self._complete_resolution_transaction(transaction, phases)
 
     def _queue_conflict(
         self,
@@ -1184,6 +1611,7 @@ class WorkspaceMemory:
         if expected_revision < 1:
             raise ValueError("expected_revision must be >= 1")
 
+        self._recover_resolution_transactions()
         existing_events = self._read_adjudications()
         duplicate = next(
             (event for event in existing_events if event.event_id == clean_event_id),
@@ -1261,6 +1689,8 @@ class WorkspaceMemory:
                 "workspace evidence changed after this conflict was detected"
             )
 
+        curated_before = tuple(deepcopy(entries))
+        conflicts_before = tuple(deepcopy(cases))
         if selected.incumbent:
             if current is None:
                 raise MemoryCorruptionError("conflict incumbent is no longer active")
@@ -1294,7 +1724,6 @@ class WorkspaceMemory:
                 current.status = CuratedStatus.SUPERSEDED.value
                 current.superseded_by = new_entry.key
             entries.append(new_entry)
-            self._save_curated(entries)
 
         timestamp = _iso(resolved_at)
         case.status = ConflictStatus.RESOLVED.value
@@ -1304,7 +1733,6 @@ class WorkspaceMemory:
         case.resolution_actor = clean_actor
         case.resolution_rationale = clean_rationale
         case.resulting_active_entry_key = resulting_key
-        self._save_conflicts(cases)
 
         event = ConflictAdjudication(
             event_id=clean_event_id,
@@ -1319,7 +1747,25 @@ class WorkspaceMemory:
             resulting_active_entry_key=resulting_key,
             evidence_ids=selected.evidence_ids,
         )
-        self._append_adjudication(event)
+        transaction = ConflictResolutionTransaction(
+            transaction_id=_resolution_transaction_id(
+                self.workspace_id, clean_event_id
+            ),
+            workspace_id=self.workspace_id,
+            conflict_id=case.conflict_id,
+            event_id=clean_event_id,
+            prepared_at=timestamp,
+            curated_before=curated_before,
+            curated_after=tuple(deepcopy(entries)),
+            conflicts_before=conflicts_before,
+            conflicts_after=tuple(deepcopy(cases)),
+            adjudication=event,
+        )
+        _validate_resolution_transaction(transaction)
+        self._append_resolution_phase(transaction, ResolutionPhase.PREPARED)
+        self._complete_resolution_transaction(
+            transaction, (ResolutionPhase.PREPARED.value,)
+        )
         return event
 
     def _load_curated(self) -> list[CuratedMemoryEntry]:

--- a/s10_workspace_memory/images/workspace-memory.svg
+++ b/s10_workspace_memory/images/workspace-memory.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 680" role="img" aria-labelledby="title desc">
-  <title id="title">工作区记忆的蒸馏、人工裁决与审计</title>
-  <desc id="desc">原始事实经过蒸馏策略；唯一胜出者进入策展历史，同分候选进入持久化冲突队列，经人工裁决后更新策展状态并追加审计事件。只有 active 修订进入 prompt。</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 800" role="img" aria-labelledby="title desc">
+  <title id="title">工作区记忆的蒸馏、事务化人工裁决与恢复</title>
+  <desc id="desc">原始事实经过蒸馏策略；同分候选进入持久化冲突队列。人工裁决先写事务日志，再更新策展状态、关闭案件并追加审计，未完成事务在重启时幂等前滚。只有 active 修订进入 prompt。</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M1 1L9 5L1 9" fill="none" stroke="context-stroke" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
@@ -15,8 +15,8 @@
       .dash{fill:none;stroke:#64748b;stroke-width:1.5;stroke-dasharray:5 5;marker-end:url(#arrow)}
     </style>
   </defs>
-  <rect width="960" height="680" fill="#f8fafc"/>
-  <text class="title" x="480" y="38" text-anchor="middle">Workspace Memory：可恢复的冲突裁决</text>
+  <rect width="960" height="800" fill="#f8fafc"/>
+  <text class="title" x="480" y="38" text-anchor="middle">Workspace Memory：事务化、可恢复的冲突裁决</text>
 
   <rect x="35" y="75" width="215" height="150" rx="12" fill="#e7f5ec" stroke="#3f9b69"/>
   <text class="heading" x="55" y="105">daily/*.jsonl</text>
@@ -74,22 +74,32 @@
   <text class="body" x="430" y="365" text-anchor="middle">selected candidate</text>
   <text class="small" x="430" y="389" text-anchor="middle">actor · rationale · event ID</text>
   <path class="line" d="M295 350H327"/>
-  <path class="line" d="M430 285V250H740V233"/>
-  <text class="small" x="585" y="272" text-anchor="middle">keep incumbent / promote challenger</text>
+  <path class="line" d="M725 505H750V250H740V233"/>
+  <text class="small" x="824" y="274" text-anchor="middle">apply curated target</text>
 
-  <rect x="335" y="465" width="390" height="95" rx="12" fill="#eef2ff" stroke="#6878bd"/>
-  <text class="heading" x="355" y="495">conflict-adjudications.jsonl</text>
-  <text class="body" x="355" y="521">append-only：选择、证据、actor 与 rationale</text>
-  <text class="small" x="355" y="544">相同 event ID 重试幂等；不同载荷 fail closed</text>
-  <path class="line" d="M430 415V457"/>
+  <rect x="335" y="450" width="390" height="110" rx="12" fill="#e8eefc" stroke="#536bb1" stroke-width="2"/>
+  <text class="heading" x="355" y="480">conflict-resolution-transactions.jsonl</text>
+  <text class="body" x="355" y="506">prepared → curated → conflict → audit → committed</text>
+  <text class="small" x="355" y="530">before / after snapshot · intent SHA-256</text>
+  <text class="small" x="355" y="550">重启比较状态并幂等前滚；第三种状态 fail closed</text>
+  <path class="line" d="M430 415V442"/>
+  <path class="line" d="M335 505H315V425H165V407"/>
+  <text class="small" x="240" y="443" text-anchor="middle">close case</text>
 
-  <rect x="35" y="465" width="260" height="95" rx="12" fill="#fff7ed" stroke="#d28a35"/>
-  <text class="heading" x="55" y="495">陈旧裁决拒绝</text>
-  <text class="body" x="55" y="521">新增证据或 active 版本变化</text>
-  <text class="small" x="55" y="544">要求 reviewer 重新加载快照</text>
-  <path class="dash" d="M335 390H315V457"/>
+  <rect x="35" y="450" width="260" height="110" rx="12" fill="#fff7ed" stroke="#d28a35"/>
+  <text class="heading" x="55" y="480">陈旧裁决拒绝</text>
+  <text class="body" x="55" y="506">prepare 前重新校验 evidence</text>
+  <text class="small" x="55" y="530">新增事实或 active 版本变化</text>
+  <text class="small" x="55" y="550">要求 reviewer 重新加载快照</text>
+  <path class="dash" d="M335 390H315V442"/>
 
-  <rect x="35" y="595" width="890" height="55" rx="12" fill="#edf2f7" stroke="#a9b2c1"/>
-  <text class="heading" x="55" y="620">不变量</text>
-  <text class="small" x="55" y="641">一个 memory_key 只有一个 active 修订 · 未决候选不进 prompt · 原始 evidence 与裁决事件只追加 · 损坏状态显式报错</text>
+  <rect x="335" y="600" width="390" height="95" rx="12" fill="#eef2ff" stroke="#6878bd"/>
+  <text class="heading" x="355" y="630">conflict-adjudications.jsonl</text>
+  <text class="body" x="355" y="656">append-only：选择、证据、actor 与 rationale</text>
+  <text class="small" x="355" y="679">相同 event ID 恢复去重；不同载荷 fail closed</text>
+  <path class="line" d="M530 560V592"/>
+
+  <rect x="35" y="730" width="890" height="45" rx="12" fill="#edf2f7" stroke="#a9b2c1"/>
+  <text class="heading" x="55" y="750">不变量</text>
+  <text class="small" x="55" y="768">单 active 修订 · 未决候选不进 prompt · evidence / journal / audit 只追加 · 不完整事务前滚 · 意外状态显式报错</text>
 </svg>

--- a/tests/test_workspace_memory.py
+++ b/tests/test_workspace_memory.py
@@ -453,6 +453,284 @@ def test_human_resolution_creates_revision_and_append_only_audit(
     assert recovered.list_adjudications() == [event]
 
 
+@pytest.mark.parametrize(
+    "fault_point",
+    [
+        "after_prepared",
+        "after_curated_write",
+        "after_curated_applied",
+        "after_conflict_write",
+        "after_conflict_closed",
+        "after_audit_write",
+        "after_audit_appended",
+        "after_committed",
+    ],
+)
+def test_resolution_transaction_recovers_every_durable_write_boundary(
+    s10,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault_point: str,
+) -> None:
+    root = tmp_path / fault_point
+    memory, as_of, _, case = _database_conflict(s10, root)
+    selected = next(
+        candidate for candidate in case.candidates if candidate.content == "Use Postgres."
+    )
+
+    def crash_at(name: str) -> None:
+        if name == fault_point:
+            raise OSError(f"simulated process exit at {name}")
+
+    monkeypatch.setattr(memory, "_resolution_checkpoint", crash_at)
+    with pytest.raises(OSError, match=fault_point):
+        memory.resolve_conflict(
+            case.conflict_id,
+            selected.candidate_id,
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="PostgreSQL is required by the reviewed deployment target.",
+            event_id=f"recovery-{fault_point}",
+            resolved_at=as_of,
+        )
+
+    recovered = s10.WorkspaceMemory(root)
+    events = recovered.list_adjudications()
+    assert len(events) == 1
+    assert events[0].event_id == f"recovery-{fault_point}"
+    assert events[0].actor == "KEDADA"
+    assert recovered.list_conflicts() == []
+    assert recovered.list_conflicts(status=None)[0].status == "resolved"
+    entries = sorted(recovered._load_curated(), key=lambda item: item.revision)
+    assert [entry.status for entry in entries] == ["superseded", "active"]
+    assert entries[-1].content == "Use Postgres."
+    assert "Use Postgres." in recovered.read_memory_md()
+
+    journal_before = recovered.resolution_transaction_file.read_text(
+        encoding="utf-8"
+    )
+    records = [json.loads(line) for line in journal_before.splitlines()]
+    assert [record["phase"] for record in records] == [
+        "prepared",
+        "curated_applied",
+        "conflict_closed",
+        "audit_appended",
+        "committed",
+    ]
+    assert len({record["transaction_id"] for record in records}) == 1
+    assert len({record["intent_sha256"] for record in records}) == 1
+
+    restarted_again = s10.WorkspaceMemory(root)
+    assert restarted_again.list_adjudications() == events
+    assert (
+        restarted_again.resolution_transaction_file.read_text(encoding="utf-8")
+        == journal_before
+    )
+
+
+def test_resolution_recovery_repairs_projection_after_curated_replace(
+    s10, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "project"
+    memory, as_of, _, case = _database_conflict(s10, root)
+    selected = next(
+        candidate for candidate in case.candidates if candidate.content == "Use Postgres."
+    )
+    old_projection = memory.memory_file.read_text(encoding="utf-8")
+    real_atomic_write = memory._atomic_write_text
+
+    def crash_after_curated_replace(path: Path, content: str) -> None:
+        real_atomic_write(path, content)
+        if path == memory.curated_file:
+            raise OSError("simulated exit after curated replace")
+
+    monkeypatch.setattr(memory, "_atomic_write_text", crash_after_curated_replace)
+    with pytest.raises(OSError, match="after curated replace"):
+        memory.resolve_conflict(
+            case.conflict_id,
+            selected.candidate_id,
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="Recover the human-facing projection from canonical state.",
+            event_id="recovery-projection-1",
+            resolved_at=as_of,
+        )
+
+    assert memory.memory_file.read_text(encoding="utf-8") == old_projection
+    recovered = s10.WorkspaceMemory(root)
+    assert "Use Postgres." in recovered.memory_file.read_text(encoding="utf-8")
+    assert len(recovered.list_adjudications()) == 1
+    assert recovered.list_conflicts(status=None)[0].status == "resolved"
+
+
+def test_resolution_recovery_keeps_incumbent_without_duplicate_revision(
+    s10, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "project"
+    memory, as_of, _, case = _database_conflict(s10, root)
+    incumbent = next(candidate for candidate in case.candidates if candidate.incumbent)
+
+    def crash_after_conflict_write(name: str) -> None:
+        if name == "after_conflict_write":
+            raise OSError("simulated incumbent resolution exit")
+
+    monkeypatch.setattr(memory, "_resolution_checkpoint", crash_after_conflict_write)
+    with pytest.raises(OSError, match="incumbent resolution exit"):
+        memory.resolve_conflict(
+            case.conflict_id,
+            incumbent.candidate_id,
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="Keep the reviewed incumbent.",
+            event_id="recovery-incumbent-1",
+            resolved_at=as_of,
+        )
+
+    recovered = s10.WorkspaceMemory(root)
+    entries = recovered._load_curated()
+    assert len(entries) == 1
+    assert entries[0].content == "Use SQLite."
+    assert entries[0].revision == 1
+    assert len(recovered.list_adjudications()) == 1
+
+
+def test_resolution_recovery_discards_partial_journal_and_audit_tails(
+    s10, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "project"
+    memory, as_of, _, case = _database_conflict(s10, root)
+    selected = next(candidate for candidate in case.candidates if not candidate.incumbent)
+
+    def crash_after_conflict_phase(name: str) -> None:
+        if name == "after_conflict_closed":
+            raise OSError("simulated exit before audit")
+
+    monkeypatch.setattr(memory, "_resolution_checkpoint", crash_after_conflict_phase)
+    with pytest.raises(OSError, match="before audit"):
+        memory.resolve_conflict(
+            case.conflict_id,
+            selected.candidate_id,
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="Recover after partial append-only records.",
+            event_id="recovery-partial-tail-1",
+            resolved_at=as_of,
+        )
+
+    with memory.resolution_transaction_file.open("ab") as handle:
+        handle.write(b'{"phase":')
+    with memory.adjudication_file.open("ab") as handle:
+        handle.write(b'{"event_id":')
+
+    recovered = s10.WorkspaceMemory(root)
+    transaction_records = [
+        json.loads(line)
+        for line in recovered.resolution_transaction_file.read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    assert [record["phase"] for record in transaction_records] == [
+        "prepared",
+        "curated_applied",
+        "conflict_closed",
+        "audit_appended",
+        "committed",
+    ]
+    assert [event.event_id for event in recovered.list_adjudications()] == [
+        "recovery-partial-tail-1"
+    ]
+
+
+def test_modified_resolution_intent_fails_closed_before_recovery(
+    s10, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "project"
+    memory, as_of, _, case = _database_conflict(s10, root)
+    selected = next(candidate for candidate in case.candidates if not candidate.incumbent)
+
+    def crash_after_prepare(name: str) -> None:
+        if name == "after_prepared":
+            raise OSError("simulated exit after prepare")
+
+    monkeypatch.setattr(memory, "_resolution_checkpoint", crash_after_prepare)
+    with pytest.raises(OSError, match="after prepare"):
+        memory.resolve_conflict(
+            case.conflict_id,
+            selected.candidate_id,
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="Original reviewed intent.",
+            event_id="recovery-tamper-1",
+            resolved_at=as_of,
+        )
+
+    record = json.loads(
+        memory.resolution_transaction_file.read_text(encoding="utf-8")
+    )
+    record["intent"]["adjudication"]["rationale"] = "Tampered intent."
+    memory.resolution_transaction_file.write_text(
+        json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(s10.MemoryCorruptionError, match="intent was modified"):
+        s10.WorkspaceMemory(root)
+    assert memory._load_conflicts()[0].status == "open"
+    assert memory._load_curated()[0].content == "Use SQLite."
+    assert memory._read_adjudications() == []
+
+
+def test_resolution_recovery_refuses_unexpected_third_state(
+    s10, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "project"
+    memory, as_of, _, case = _database_conflict(s10, root)
+    selected = next(candidate for candidate in case.candidates if not candidate.incumbent)
+
+    def crash_after_prepare(name: str) -> None:
+        if name == "after_prepared":
+            raise OSError("simulated exit before canonical writes")
+
+    monkeypatch.setattr(memory, "_resolution_checkpoint", crash_after_prepare)
+    with pytest.raises(OSError, match="before canonical writes"):
+        memory.resolve_conflict(
+            case.conflict_id,
+            selected.candidate_id,
+            expected_revision=case.revision,
+            actor="KEDADA",
+            rationale="Do not overwrite unrelated post-prepare state.",
+            event_id="recovery-third-state-1",
+            resolved_at=as_of,
+        )
+
+    payload = json.loads(memory.curated_file.read_text(encoding="utf-8"))
+    payload["entries"].append(
+        {
+            "key": "unrelated-valid-entry",
+            "kind": "convention",
+            "content": "An unrelated writer changed curated state.",
+            "first_seen": "2026-01-01T12:00:00Z",
+            "last_seen": "2026-01-01T12:00:00Z",
+            "evidence_ids": ["unrelated-fact"],
+            "occurrences": 1,
+            "memory_key": None,
+            "revision": 1,
+            "status": "active",
+            "supersedes": None,
+            "superseded_by": None,
+        }
+    )
+    memory.curated_file.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(s10.MemoryCorruptionError, match="unexpected curated state"):
+        s10.WorkspaceMemory(root)
+    assert memory._load_conflicts()[0].status == "open"
+    assert memory._read_adjudications() == []
+
+
 def test_resolution_retry_is_idempotent_and_event_reuse_is_rejected(
     s10, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

- add an append-only five-phase transaction journal for multi-file human conflict adjudication
- recover incomplete transactions by comparing durable before/after snapshots and rolling forward idempotently
- repair partial JSONL tails, reject modified intents and unexpected third states, and avoid duplicate revisions or audit events
- document the recovery contract and update the S10 architecture diagram

## Verification

- `python -m pytest tests/test_workspace_memory.py -q` — 33 passed
- `python -m py_compile s10_workspace_memory/code.py`
- `git diff --check upstream/main...HEAD`