### PR TITLE
feat(s13): add reference-aware artifact retention and GC

### DIFF
--- a/examples/layered_memory_walkthrough/README.md
+++ b/examples/layered_memory_walkthrough/README.md
@@ -15,6 +15,9 @@ flowchart LR
   W["S10 Workspace log"] --> D["distill / curated view"]
   U["S11 keyed user preference"] --> I["scope isolation"]
   A["S13 Artifact"] --> P["bounded pointer + digest"]
+  P --> L["retention claim"]
+  L --> G["plan/apply cleanup"]
+  G --> K["referenced retained / orphan deleted"]
   R --> F["fresh-process recovery"]
   D --> F
   I --> F
@@ -39,6 +42,7 @@ flowchart LR
 | User preference | S11 用户记忆 | 用户级、跨项目 | 显式按 key 更新，不做模糊追加 |
 | Recall hit | S12 查询结果 | 单 query | 是；它只是带 source 和 score 的候选视图 |
 | Artifact | S13 大结果证据 | session artifact | 原文件不允许；Prompt 只留摘要和指针 |
+| Retention claim | S13 清理租约 | Memory 引用期 | 无正文、无路径；只保护匹配 source/digest 的 Artifact |
 | Compacted messages | S14 Prompt 视图 | 单次或少数几次模型调用 | 允许；durable state 必须走无损旁路 |
 | Source resolution | S14 本轮核验视图 | 单次 Prompt 组装 | 不复用旧状态；每轮从 owner 重新核验 |
 
@@ -56,7 +60,7 @@ python3 examples/layered_memory_walkthrough/code.py --home /tmp/layered-memory
 
 `--home` 必须指向一个尚未生成 walkthrough manifest 的目录。这样重复实验不会静默覆盖上一轮证据。
 
-正常输出包含六个阶段：
+正常输出包含七个阶段：
 
 ```text
 [1] Transcript evidence
@@ -64,7 +68,8 @@ python3 examples/layered_memory_walkthrough/code.py --home /tmp/layered-memory
 [3] Workspace log and distill
 [4] User preference dedup and isolation
 [5] Query-scoped recall
-[6] Compaction boundary — sources verified=2
+[6] Reference-aware artifact cleanup
+[7] Compaction boundary — sources verified=2
 RESULT: OK — layered memory boundaries survived compaction and restart.
 ```
 
@@ -76,8 +81,9 @@ RESULT: OK — layered memory boundaries survived compaction and restart.
 4. S11 为 Alice 写入 keyed preference。相同 key/value 的第二次写入返回 `unchanged`，不增加 revision；Bob 使用同一 state root 仍得到空偏好，证明 user scope 隔离。
 5. S12 把 S09 candidate 写成 source-bearing conversation record，再为一个自包含 query 生成带 rank、score 和 provenance 的 RecallHit。Recall 不修改 Workspace 或 User Memory。
 6. walkthrough 丢弃所有对象并用相同路径创建新实例，分别恢复 Transcript、Workspace、User、Remote Store 和 Artifact。随后根据恢复结果重建 S14 `DurableContextState`。
-7. 为了在小 fixture 中确定性触发 S14，代码临时降低当前模块实例的压缩阈值，并在 `finally` 中恢复。对抗性 summarizer 会谎称“任务已完成”，测试要求错误只能进入 conversation summary，不能进入 durable context。
-8. 压缩完成后创建新的 `SourcePointerResolver`，从可信 Transcript / Artifact 根重新核验两个 pointer。只有结构、owner 和 SHA-256 全部通过才得到 `available`；Prompt 只接收 status 与 evidence hash，bounded excerpt 不进入 durable context，manifest 也不复制正文。
+7. fresh S13 externalizer 从 Memory reference 生成无路径 retention claim，再用两阶段 cleanup 保留被引用的旧 Artifact、删除同龄但无 owner 的孤儿；report 不复制正文或物理路径。
+8. 为了在小 fixture 中确定性触发 S14，代码临时降低当前模块实例的压缩阈值，并在 `finally` 中恢复。对抗性 summarizer 会谎称“任务已完成”，测试要求错误只能进入 conversation summary，不能进入 durable context。
+9. 压缩完成后创建新的 `SourcePointerResolver`，从可信 Transcript / Artifact 根重新核验两个 durable pointer，并确认已清理孤儿得到 `missing`。Prompt 只接收 status 与 evidence hash，bounded excerpt 不进入 durable context，manifest 也不复制正文。
 
 ## 为什么 S12 改成延迟初始化
 
@@ -102,8 +108,8 @@ online agent_loop 真正调用模型
 
 运行目录里的 `layered_memory_manifest.json` 分三部分：
 
-- `checks`：十个布尔不变量，包括去重、隔离、来源恢复、Artifact digest、source pointer 核验和 compaction 边界。
-- `layers`：每一层的可观察结果，例如 distill report、RecallHit、ArtifactMemoryReference、压缩前后 token、触发层和不含 excerpt 的 source resolutions。
+- `checks`：十一个布尔不变量，包括去重、隔离、来源恢复、引用感知 cleanup、Artifact digest、source pointer 核验和 compaction 边界。
+- `layers`：每一层的可观察结果，例如 distill report、RecallHit、ArtifactMemoryReference、不含路径的 cleanup report、压缩前后 token、触发层和不含 excerpt 的 source resolutions。
 - `artifacts`：Transcript JSONL、Workspace log/curated view、User preferences、Remote store 和 tool result 的真实路径。
 
 Manifest 只是一份验收报告，不是新的 Memory 真源。需要核验时仍应打开对应 owner 的文件。
@@ -114,6 +120,7 @@ Manifest 只是一份验收报告，不是新的 Memory 真源。需要核验时
 - **重复不等于多存一份。** Workspace 用 evidence IDs 合并重复事实；User preference 用稳定 key 返回 `unchanged`。
 - **同一 state root 不等于同一用户。** Alice 和 Bob 的 scope digest 不同，不能互读 canonical state。
 - **引用不等于复制。** Memory-facing Artifact reference 没有 `content` 字段，大结果仍归 Artifact 文件所有。
+- **清理不等于删除整个 session。** active claim 只按 source ID + 完整 digest 保护对应证据；达到 TTL 的无引用孤儿才能在重验后删除。
 - **恢复不等于复用旧对象。** walkthrough 明确创建 fresh store instances，再从磁盘重建视图。
 - **摘要不拥有事实。** S14 只压缩 messages 副本，source-bearing facts 和 pending items 单独渲染。
 - **Pointer 不等于已验证证据。** fresh resolver 必须从 owner 重新得到 `available`；清理、拒绝、损坏或未知 scheme 都会显式渲染 `evidence_unavailable=true`，不能由摘要补齐。

--- a/examples/layered_memory_walkthrough/code.py
+++ b/examples/layered_memory_walkthrough/code.py
@@ -15,6 +15,7 @@ import argparse
 import copy
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 from dataclasses import asdict, dataclass
@@ -181,6 +182,16 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         summary="Build verification completed for the layered memory walkthrough.",
     )
     artifact_memory = externalized.artifact.for_memory()
+    orphaned_artifact = externalizer.externalize(
+        "temporary diagnostic output",
+        "search",
+        summary="Temporary diagnostic output with no durable owner.",
+    ).artifact
+    for artifact_path in (externalized.artifact.path, orphaned_artifact.path):
+        os.utime(
+            artifact_path,
+            (recorded_at.timestamp(), recorded_at.timestamp()),
+        )
     _print_stage(2, "Artifact reference", artifact_memory.source.source_id)
 
     # 3. Workspace memory keeps project facts in an append log, then distills
@@ -295,10 +306,31 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         as_of=as_of,
     )
     restarted_externalizer = chapters.s13.ToolResultExternalizer(artifact_session)
+    cleanup_claim = chapters.s13.ArtifactRetentionClaim.from_memory_reference(
+        artifact_memory,
+    )
+    cleanup_plan = restarted_externalizer.plan_cleanup(
+        (cleanup_claim,),
+        policy=chapters.s13.ArtifactCleanupPolicy(
+            orphan_ttl_seconds=24 * 60 * 60,
+            dry_run=False,
+        ),
+        now=as_of,
+    )
+    cleanup_report = restarted_externalizer.apply_cleanup(
+        cleanup_plan,
+        claims=(cleanup_claim,),
+        now=as_of,
+    )
     recovered_artifact_head = restarted_externalizer.read_artifact(
         externalized.artifact,
         offset=0,
         limit=2,
+    )
+    _print_stage(
+        6,
+        "Reference-aware artifact cleanup",
+        "referenced retained=1; expired orphan deleted=1",
     )
 
     durable_state = chapters.s14.DurableContextState(
@@ -358,6 +390,9 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         compacted.durable_state,
         source_resolver,
     )
+    orphan_resolution = source_resolver.resolve(
+        orphaned_artifact.source.source_id,
+    )
     durable_context = chapters.s14.render_durable_context(
         compacted.durable_state,
         source_resolutions=source_resolutions,
@@ -375,7 +410,7 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         and messages == original_messages
     )
     _print_stage(
-        6,
+        7,
         "Compaction boundary",
         f"layers={','.join(compacted.applied_layers)}; "
         f"durable preserved={durable_state_preserved}; "
@@ -405,6 +440,16 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         "artifact_recovered_with_digest": (
             "build verification log" in recovered_artifact_head
             and len(artifact_memory.content_sha256) == 64
+        ),
+        "artifact_cleanup_preserved_references": (
+            cleanup_report.counts == {
+                "retained_referenced": 1,
+                "deleted": 1,
+            }
+            and externalized.artifact.path.exists()
+            and not orphaned_artifact.path.exists()
+            and orphan_resolution.status
+            is chapters.s14.SourceResolutionStatus.MISSING
         ),
         "compaction_exercised": bool(compacted.applied_layers),
         "adversarial_summary_exercised": poisoned_summary_visible,
@@ -439,7 +484,13 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
             "query_id": recovered_recall.query.query_id,
             "hits": [hit.to_dict() for hit in recovered_recall.hits],
         },
-        "artifact": artifact_memory.to_dict(),
+        "artifact": {
+            "reference": artifact_memory.to_dict(),
+            "cleanup": cleanup_report.to_dict(),
+            "orphan_resolution": orphan_resolution.to_dict(
+                include_excerpt=False,
+            ),
+        },
         "compaction": {
             "applied_layers": list(compacted.applied_layers),
             "tokens_before": compacted.tokens_before,

--- a/s13_output_externalization/README.md
+++ b/s13_output_externalization/README.md
@@ -18,6 +18,10 @@ flowchart LR
     D --> E["Read Page Fault"]
     C --> F["ArtifactReference<br/>digest + provenance"]
     F -. "later policy" .-> G["Memory Reference<br/>summary + pointer, no body"]
+    G --> H["ArtifactRetentionClaim<br/>source ID + digest + lease"]
+    C --> I["plan_cleanup → snapshot"]
+    H --> I
+    I --> J["retain referenced / recent<br/>delete expired orphan"]
 ```
 
 ## 学习前置知识
@@ -31,6 +35,8 @@ flowchart LR
 - 把大输出 swap 到 artifact 文件, prompt 里只留摘要和路径。
 - 为 artifact 生成稳定 source ID、摘要、来源工具、时间与 SHA-256，避免它变成不可审计的匿名文件。
 - Memory 只能接收 `ArtifactMemoryReference`，保留必要摘要与可检索指针，不复制大结果正文。
+- 用无路径 `ArtifactRetentionClaim` 把 Memory 引用投影为清理租约；物理路径始终由 S13 的可信 session root 决定。
+- 清理分成 plan/apply 两阶段，执行前重新核验文件 identity、mtime、大小与 SHA-256；变化时 fail-closed。
 - 模拟按需读取片段, 类似缺页中断。
 - 为 s14 的压缩减轻压力。
 
@@ -41,6 +47,10 @@ flowchart LR
 - 外部化文件不纳入审计, 会影响复盘。
 - 用进程内计数器重新从 `001` 写起，会覆盖旧 artifact，让已经保存的 pointer 指向错误证据。
 - 把 pointer 中的 head/tail 预览原样写进 Memory，本质上仍在复制可能巨大或敏感的工具正文。
+- 会话结束就删除整个 `tool-results/`，会让仍被 Workspace/User Memory 引用的证据立即悬空。
+- 直接相信 Memory 中的 `artifact_path` 做删除，会把不可信持久化数据变成任意文件删除入口。
+- 扫描到未知文件、符号链接、digest 冲突或竞态仍继续删除，违背证据清理的 fail-closed 边界。
+
 ## 问题
 
 一条 `grep -r "TODO" .` 命令能产生多少输出？
@@ -189,6 +199,55 @@ payload = memory_reference.to_dict()
 ```
 
 `source` 与 s09、s12 使用同一组核心字段：`source_id`、`source_type`、`title`、`captured_at`。其中 `source_id` 组合 session、artifact 文件名和内容摘要前缀；`content_sha256` 用于发现文件被替换或损坏。这里没有直接写入 Memory，因为 artifact 是否值得跨会话保留，仍需后续 policy 判断。
+
+### 引用感知的生命周期与 GC
+
+Artifact 不能永久累积，也不能跟随 session 一刀切删除。S13 把“是否还需要这份证据”建模成有界租约：
+
+```text
+ArtifactMemoryReference
+    └─ ArtifactRetentionClaim
+         ├─ source_id              # path-free owner identity
+         ├─ content_sha256         # full digest
+         ├─ reference_count        # Memory adapter 聚合的活跃引用数
+         └─ retain_until?          # 可选租约截止时间
+```
+
+`ArtifactRetentionClaim` 刻意没有路径。清理器只解析 `artifact:<session>:<filename>:<digest>`，并要求 session 与当前 `ToolResultExternalizer` 一致；文件最终位置只能从可信 `session_dir/tool-results` 推导。跨 session claim、路径分量和不匹配 digest 在删除前就会被拒绝。
+
+清理分成两个阶段：
+
+1. `plan_cleanup()` 只读扫描，流式计算 SHA-256，并冻结 size、mtime、device 与 inode 快照；默认 policy 为 dry-run。
+2. `apply_cleanup()` 只处理计划中的 `planned_delete`，并强制接收执行时的当前 claim 视图；新增 active claim 会保留文件。删除前还会重新检查 ownership、文件类型、快照和 digest，任何变化都 fail-closed。
+
+| 状态 | 含义 | 是否删除 |
+|---|---|---|
+| `retained_referenced` | active claim 与完整 digest 都匹配 | 否 |
+| `retained_recent` | 尚未达到 orphan TTL | 否 |
+| `retained_limit` | 本轮达到最大删除数量 | 否 |
+| `retained_unknown` / `denied` | 非 S13 文件、目录或符号链接边界 | 否 |
+| `retained_corrupt` | claim 与文件 digest/快照矛盾 | 否 |
+| `missing_referenced` | active claim 指向的 artifact 已不存在 | 无文件可删，显式报告悬空引用 |
+| `planned_delete` | 已过 TTL 且没有 active claim | dry-run 仅报告 |
+| `deleted` | apply 阶段重验成功 | 是 |
+| `already_missing` / `race_detected` | 重复执行或 plan 后文件发生变化 | 否 |
+
+```python
+claim = ArtifactRetentionClaim.from_memory_reference(
+    memory_reference,
+    reference_count=2,
+    retain_until="2026-09-01T00:00:00+00:00",
+)
+policy = ArtifactCleanupPolicy(
+    orphan_ttl_seconds=24 * 60 * 60,
+    max_deletions=100,
+    dry_run=False,
+)
+plan = externalizer.plan_cleanup((claim,), policy=policy)
+report = externalizer.apply_cleanup(plan, claims=(claim,))
+```
+
+`reference_count` 由可信 Memory adapter 聚合，不让模型直接声明；claim 缺席或租约过期后，文件仍必须超过 orphan TTL 才有资格删除。非 dry-run apply 若没有显式的当前 claim 视图会直接拒绝，调用方应在同一一致性边界内读取 claims 并执行 apply。cleanup plan/report 只公开 filename、source ID、digest、age 和 reason，不泄露或接受物理路径。这个教学实现把竞态窗口压缩到删除前的 claim 与文件二次校验；生产系统若有并发 writer，还应增加 session lease、目录锁或对象存储条件删除。
 
 ### 按需读取 (Read = 缺页中断)
 
@@ -403,16 +462,24 @@ if (resultSize > CODEBUDDY_TOOL_RESULT_THRESHOLD_KB * 1024) {
    - `for_memory()` 进一步生成瘦引用；没有 `content` 字段，也不复制 pointer 中的预览
    - 读取路径被限制在当前 session 的 `tool-results/` 下，pointer 不能变成任意文件读取入口
 
-3. **`MockLLM`** — 模拟 LLM 的行为
+3. **`ArtifactRetentionClaim` / `ArtifactCleanupPolicy`** — 引用租约与清理策略
+   - claim 只携带 typed source ID、完整 digest、引用计数与可选过期时间，不接受 Memory 路径
+   - policy 显式控制 orphan TTL、最大删除数量和 dry-run
+
+4. **`ArtifactCleanupPlan` / `ArtifactCleanupReport`** — 两阶段、可审计清理
+   - plan 冻结文件快照并解释每个 retain/delete 决策，不产生写操作
+   - apply 重验归属、identity 与 digest；支持竞态检测和重复执行幂等
+
+5. **`MockLLM`** — 模拟 LLM 的行为
    - 按预设脚本生成工具调用
    - 看到外部化指针时，决定是否触发"缺页中断"（调 Read 读完整输出）
 
-4. **Agent 循环** — 集成外部化
+6. **Agent 循环** — 集成外部化
    - 工具执行后检查是否需要外部化
    - 需要则写 artifact + 生成结构化 reference + 替换上下文内容
    - 打印 `[externalize]` 日志，显示节省效果
 
-5. **Demo 场景** — 完整演示
+7. **Demo 场景** — 完整演示
    - 模拟一条产生 1.3MB 输出的 grep 命令
    - 展示外部化前后的上下文大小对比
    - 模拟 agent 需要完整输出时的缺页中断
@@ -442,7 +509,7 @@ python s13_output_externalization/code.py
 ## 练习
 
 1. 当前 `make_pointer` 保留 head 6KB + tail 24KB。如果 agent 最常需要的是输出的中间部分（比如第 40000 行的错误），怎么改进预览策略？提示：考虑基于正则匹配的关键行提取，或分块索引。
-2. 给 `ToolResultExternalizer` 加一个清理机制：会话结束时删除未被引用的 `tool-results/` 文件。但如果 Memory 仍持有某个 `ArtifactMemoryReference`，清理器应如何用 source ID、TTL 和引用计数避免产生悬空指针？
+2. 把进程内的 retention claims 持久化为 append-only lease journal，并实现 crash recovery。证明“引用写入成功但 claim 尚未落盘”时清理器仍然 fail-closed。
 3. 当前的 `should_externalize` 只看输出大小。如果一条命令的输出是 30KB 的随机字符串（对 agent 无用）vs 30KB 的结构化 JSON（每行都有用），应该用不同策略吗？思考：能否让外部化策略感知输出的信息密度？
 
 ---

--- a/s13_output_externalization/code.py
+++ b/s13_output_externalization/code.py
@@ -31,9 +31,12 @@ Usage:
 import argparse
 import hashlib
 import os
+import re
 import tempfile
-from dataclasses import asdict, dataclass
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 
 # Machine-readable learning path metadata. Tests enforce that every
@@ -45,6 +48,7 @@ PROGRESSION = {
         "large output threshold",
         "source-bearing artifact references",
         "page-fault reads",
+        "reference-aware artifact retention",
     ],
     "preserves": ["context budget mindset", "memory as a selective derived view"],
 }
@@ -69,6 +73,11 @@ HEAD_BYTES = 6 * 1024                    # 6KB head in pointer
 TAIL_BYTES = 24 * 1024                   # 24KB tail in pointer
 SUMMARY_MAX_CHARS = 240                  # bounded text suitable for later retrieval
 ARTIFACT_SOURCE_TYPE = "artifact"
+DEFAULT_ORPHAN_TTL_SECONDS = 24 * 60 * 60
+_SOURCE_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$")
+_ARTIFACT_DIGEST_PATTERN = re.compile(r"^(?:[0-9a-fA-F]{12}|[0-9a-fA-F]{64})$")
+_FULL_SHA256_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
+_ARTIFACT_FILENAME_PATTERN = re.compile(r"^tool_result_[0-9]{3,}\.txt$")
 
 
 class ArtifactAccessError(ValueError):
@@ -77,6 +86,84 @@ class ArtifactAccessError(ValueError):
 
 class ArtifactIntegrityError(RuntimeError):
     """Persisted artifact bytes no longer match the reference digest."""
+
+
+class ArtifactRetentionError(ValueError):
+    """A retention claim or cleanup plan violated an ownership contract."""
+
+
+class ArtifactCleanupStatus(str, Enum):
+    """Terminal or planned state for one artifact cleanup decision."""
+
+    RETAINED_REFERENCED = "retained_referenced"
+    RETAINED_RECENT = "retained_recent"
+    RETAINED_LIMIT = "retained_limit"
+    RETAINED_UNKNOWN = "retained_unknown"
+    RETAINED_CORRUPT = "retained_corrupt"
+    PLANNED_DELETE = "planned_delete"
+    DELETED = "deleted"
+    MISSING_REFERENCED = "missing_referenced"
+    ALREADY_MISSING = "already_missing"
+    RACE_DETECTED = "race_detected"
+    DENIED = "denied"
+
+
+@dataclass(frozen=True)
+class ParsedArtifactSource:
+    """Path-free parts of an S13-owned artifact source ID."""
+
+    raw: str
+    session_id: str
+    filename: str
+    digest_prefix: str
+
+
+def _source_component(value: str, *, field_name: str) -> str:
+    if value in {".", ".."} or not _SOURCE_COMPONENT_PATTERN.fullmatch(value):
+        raise ArtifactRetentionError(f"{field_name} must be one path-free component")
+    return value
+
+
+def parse_artifact_source_id(value: str) -> ParsedArtifactSource:
+    """Parse an artifact ID without accepting a caller-controlled path."""
+
+    raw = str(value)
+    if not raw or any(character.isspace() for character in raw):
+        raise ArtifactRetentionError("artifact source ID must be non-empty and path-free")
+    parts = raw.split(":")
+    if len(parts) != 4 or parts[0] != ARTIFACT_SOURCE_TYPE:
+        raise ArtifactRetentionError(
+            "artifact source ID must be artifact:<session>:<filename>:<digest>"
+        )
+    session_id = _source_component(parts[1], field_name="artifact session")
+    filename = _source_component(parts[2], field_name="artifact filename")
+    if not _ARTIFACT_FILENAME_PATTERN.fullmatch(filename):
+        raise ArtifactRetentionError("artifact filename is not owned by S13")
+    if not _ARTIFACT_DIGEST_PATTERN.fullmatch(parts[3]):
+        raise ArtifactRetentionError("artifact digest must contain 12 or 64 hex characters")
+    return ParsedArtifactSource(
+        raw=raw,
+        session_id=session_id,
+        filename=filename,
+        digest_prefix=parts[3].lower(),
+    )
+
+
+def _aware_utc(value: datetime | None = None) -> datetime:
+    observed = value or datetime.now(timezone.utc)
+    if observed.tzinfo is None:
+        raise ValueError("cleanup time must include a timezone")
+    return observed.astimezone(timezone.utc)
+
+
+def _parse_aware_utc(value: str, *, field_name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ArtifactRetentionError(f"{field_name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ArtifactRetentionError(f"{field_name} must include a timezone")
+    return parsed.astimezone(timezone.utc)
 
 
 @dataclass(frozen=True)
@@ -145,6 +232,157 @@ class ExternalizedToolResult:
     artifact: ArtifactReference
 
 
+@dataclass(frozen=True)
+class ArtifactRetentionClaim:
+    """A bounded Memory lease that protects one immutable artifact.
+
+    The physical path is deliberately absent. Cleanup resolves the typed source
+    ID beneath its own trusted session root and verifies the full digest before
+    treating the claim as authoritative.
+    """
+
+    source_id: str
+    content_sha256: str
+    reference_count: int = 1
+    retain_until: str | None = None
+
+    def __post_init__(self) -> None:
+        parsed = parse_artifact_source_id(self.source_id)
+        digest = str(self.content_sha256).lower()
+        if not _FULL_SHA256_PATTERN.fullmatch(digest):
+            raise ArtifactRetentionError("retention claim requires a full SHA-256 digest")
+        if not digest.startswith(parsed.digest_prefix):
+            raise ArtifactRetentionError("source ID digest does not match retention digest")
+        if (
+            isinstance(self.reference_count, bool)
+            or not isinstance(self.reference_count, int)
+            or self.reference_count < 1
+        ):
+            raise ArtifactRetentionError("reference_count must be a positive integer")
+        if self.retain_until is not None:
+            _parse_aware_utc(self.retain_until, field_name="retain_until")
+        object.__setattr__(self, "content_sha256", digest)
+
+    @classmethod
+    def from_memory_reference(
+        cls,
+        reference: ArtifactMemoryReference,
+        *,
+        reference_count: int = 1,
+        retain_until: str | None = None,
+    ) -> ArtifactRetentionClaim:
+        return cls(
+            source_id=reference.source.source_id,
+            content_sha256=reference.content_sha256,
+            reference_count=reference_count,
+            retain_until=retain_until,
+        )
+
+    def is_active(self, now: datetime) -> bool:
+        if self.retain_until is None:
+            return True
+        return _parse_aware_utc(
+            self.retain_until,
+            field_name="retain_until",
+        ) > _aware_utc(now)
+
+
+@dataclass(frozen=True)
+class ArtifactCleanupPolicy:
+    """Deterministic limits for deleting expired, unreferenced artifacts."""
+
+    orphan_ttl_seconds: int = DEFAULT_ORPHAN_TTL_SECONDS
+    max_deletions: int | None = None
+    dry_run: bool = True
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.orphan_ttl_seconds, bool)
+            or not isinstance(self.orphan_ttl_seconds, int)
+            or self.orphan_ttl_seconds < 0
+        ):
+            raise ValueError("orphan_ttl_seconds must be a non-negative integer")
+        if self.max_deletions is not None and (
+            isinstance(self.max_deletions, bool)
+            or not isinstance(self.max_deletions, int)
+            or self.max_deletions < 0
+        ):
+            raise ValueError("max_deletions must be a non-negative integer or None")
+        if not isinstance(self.dry_run, bool):
+            raise ValueError("dry_run must be a boolean")
+
+
+@dataclass(frozen=True)
+class ArtifactCleanupDecision:
+    """One explainable retain/delete outcome without exposing a disk path."""
+
+    filename: str
+    source_id: str | None
+    status: ArtifactCleanupStatus
+    reason: str
+    byte_size: int | None = None
+    content_sha256: str | None = None
+    age_seconds: int | None = None
+    reference_count: int = 0
+    snapshot_mtime_ns: int | None = None
+    snapshot_device: int | None = None
+    snapshot_inode: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["status"] = self.status.value
+        payload.pop("snapshot_mtime_ns")
+        payload.pop("snapshot_device")
+        payload.pop("snapshot_inode")
+        return payload
+
+
+@dataclass(frozen=True)
+class ArtifactCleanupPlan:
+    """Immutable phase-one snapshot; no file is deleted while planning."""
+
+    session_id: str
+    planned_at: str
+    policy: ArtifactCleanupPolicy
+    decisions: tuple[ArtifactCleanupDecision, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "planned_at": self.planned_at,
+            "policy": asdict(self.policy),
+            "decisions": [decision.to_dict() for decision in self.decisions],
+        }
+
+
+@dataclass(frozen=True)
+class ArtifactCleanupReport:
+    """Phase-two cleanup outcomes and stable status counts."""
+
+    session_id: str
+    planned_at: str
+    applied_at: str
+    dry_run: bool
+    decisions: tuple[ArtifactCleanupDecision, ...]
+
+    @property
+    def counts(self) -> dict[str, int]:
+        counts = {status.value: 0 for status in ArtifactCleanupStatus}
+        for decision in self.decisions:
+            counts[decision.status.value] += 1
+        return {name: count for name, count in counts.items() if count}
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "planned_at": self.planned_at,
+            "applied_at": self.applied_at,
+            "dry_run": self.dry_run,
+            "counts": self.counts,
+            "decisions": [decision.to_dict() for decision in self.decisions],
+        }
+
+
 # ======================================================================
 # Token estimation (same rough heuristic as s18)
 # ======================================================================
@@ -191,6 +429,7 @@ class ToolResultExternalizer:
 
     def __init__(self, session_dir: Path):
         self.session_dir = session_dir
+        _source_component(self.session_dir.name, field_name="artifact session")
         self.tool_results_dir = session_dir / "tool-results"
         self.tool_results_dir.mkdir(parents=True, exist_ok=True)
         self._counter = 0
@@ -401,6 +640,339 @@ class ToolResultExternalizer:
             offset=offset,
             limit=limit,
         )
+
+    @staticmethod
+    def _stream_sha256(file_path: Path) -> str:
+        digest = hashlib.sha256()
+        with file_path.open("rb") as handle:
+            while chunk := handle.read(64 * 1024):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _validated_claims(
+        self,
+        claims: Sequence[ArtifactRetentionClaim],
+        *,
+        now: datetime,
+    ) -> tuple[
+        dict[str, ArtifactRetentionClaim],
+        dict[str, ArtifactRetentionClaim],
+    ]:
+        by_source: dict[str, ArtifactRetentionClaim] = {}
+        active_by_filename: dict[str, ArtifactRetentionClaim] = {}
+        all_by_filename: dict[str, ArtifactRetentionClaim] = {}
+        for claim in claims:
+            if not isinstance(claim, ArtifactRetentionClaim):
+                raise ArtifactRetentionError(
+                    "cleanup claims must be ArtifactRetentionClaim values"
+                )
+            parsed = parse_artifact_source_id(claim.source_id)
+            if parsed.session_id != self.session_dir.name:
+                raise ArtifactRetentionError(
+                    "retention claim belongs to a different artifact session"
+                )
+            if claim.source_id in by_source:
+                raise ArtifactRetentionError(
+                    f"duplicate retention source ID: {claim.source_id}"
+                )
+            if parsed.filename in all_by_filename:
+                raise ArtifactRetentionError(
+                    f"multiple retention claims target {parsed.filename}"
+                )
+            by_source[claim.source_id] = claim
+            all_by_filename[parsed.filename] = claim
+            if claim.is_active(now):
+                active_by_filename[parsed.filename] = claim
+        return all_by_filename, active_by_filename
+
+    def plan_cleanup(
+        self,
+        claims: Sequence[ArtifactRetentionClaim] = (),
+        *,
+        policy: ArtifactCleanupPolicy | None = None,
+        now: datetime | None = None,
+    ) -> ArtifactCleanupPlan:
+        """Plan cleanup without deleting data or trusting Memory-owned paths."""
+
+        observed_at = _aware_utc(now)
+        active_policy = policy or ArtifactCleanupPolicy()
+        all_claims, active_claims = self._validated_claims(
+            claims,
+            now=observed_at,
+        )
+        decisions: list[ArtifactCleanupDecision] = []
+        seen_active_claims: set[str] = set()
+        planned_deletions = 0
+
+        for candidate in sorted(self.tool_results_dir.iterdir(), key=lambda path: path.name):
+            filename = candidate.name
+            if not _ARTIFACT_FILENAME_PATTERN.fullmatch(filename):
+                decisions.append(ArtifactCleanupDecision(
+                    filename=filename,
+                    source_id=None,
+                    status=ArtifactCleanupStatus.RETAINED_UNKNOWN,
+                    reason="filename_not_owned_by_s13",
+                ))
+                continue
+            if filename in active_claims:
+                seen_active_claims.add(active_claims[filename].source_id)
+            try:
+                if candidate.is_symlink():
+                    decisions.append(ArtifactCleanupDecision(
+                        filename=filename,
+                        source_id=None,
+                        status=ArtifactCleanupStatus.DENIED,
+                        reason="symbolic_link_not_owned",
+                    ))
+                    continue
+                owned_path = self._owned_path(candidate)
+                snapshot = owned_path.stat()
+                if not owned_path.is_file():
+                    decisions.append(ArtifactCleanupDecision(
+                        filename=filename,
+                        source_id=None,
+                        status=ArtifactCleanupStatus.RETAINED_UNKNOWN,
+                        reason="artifact_not_a_regular_file",
+                    ))
+                    continue
+                digest = self._stream_sha256(owned_path)
+            except PermissionError:
+                decisions.append(ArtifactCleanupDecision(
+                    filename=filename,
+                    source_id=None,
+                    status=ArtifactCleanupStatus.DENIED,
+                    reason="artifact_read_denied",
+                ))
+                continue
+            except (ArtifactAccessError, OSError):
+                decisions.append(ArtifactCleanupDecision(
+                    filename=filename,
+                    source_id=None,
+                    status=ArtifactCleanupStatus.RETAINED_CORRUPT,
+                    reason="artifact_snapshot_failed",
+                ))
+                continue
+
+            source_id = (
+                f"artifact:{self.session_dir.name}:{filename}:{digest[:12]}"
+            )
+            age_seconds = max(
+                0,
+                int(observed_at.timestamp() - snapshot.st_mtime),
+            )
+            claim = all_claims.get(filename)
+            common = {
+                "filename": filename,
+                "source_id": source_id,
+                "byte_size": snapshot.st_size,
+                "content_sha256": digest,
+                "age_seconds": age_seconds,
+                "reference_count": claim.reference_count if claim else 0,
+                "snapshot_mtime_ns": snapshot.st_mtime_ns,
+                "snapshot_device": snapshot.st_dev,
+                "snapshot_inode": snapshot.st_ino,
+            }
+            if claim is not None and (
+                claim.content_sha256 != digest
+            ):
+                decisions.append(ArtifactCleanupDecision(
+                    **common,
+                    status=ArtifactCleanupStatus.RETAINED_CORRUPT,
+                    reason="retention_claim_digest_mismatch",
+                ))
+                continue
+            if filename in active_claims:
+                decisions.append(ArtifactCleanupDecision(
+                    **common,
+                    status=ArtifactCleanupStatus.RETAINED_REFERENCED,
+                    reason="active_memory_retention_claim",
+                ))
+                continue
+            if age_seconds < active_policy.orphan_ttl_seconds:
+                decisions.append(ArtifactCleanupDecision(
+                    **common,
+                    status=ArtifactCleanupStatus.RETAINED_RECENT,
+                    reason=(
+                        "retention_claim_expired_but_orphan_ttl_not_reached"
+                        if claim is not None
+                        else "orphan_ttl_not_reached"
+                    ),
+                ))
+                continue
+            if (
+                active_policy.max_deletions is not None
+                and planned_deletions >= active_policy.max_deletions
+            ):
+                decisions.append(ArtifactCleanupDecision(
+                    **common,
+                    status=ArtifactCleanupStatus.RETAINED_LIMIT,
+                    reason="cleanup_deletion_limit_reached",
+                ))
+                continue
+            planned_deletions += 1
+            decisions.append(ArtifactCleanupDecision(
+                **common,
+                status=ArtifactCleanupStatus.PLANNED_DELETE,
+                reason=(
+                    "expired_retention_claim"
+                    if claim is not None
+                    else "expired_unreferenced_artifact"
+                ),
+            ))
+
+        for filename, claim in sorted(active_claims.items()):
+            if claim.source_id in seen_active_claims:
+                continue
+            decisions.append(ArtifactCleanupDecision(
+                filename=filename,
+                source_id=claim.source_id,
+                status=ArtifactCleanupStatus.MISSING_REFERENCED,
+                reason="active_retention_claim_has_no_artifact",
+                content_sha256=claim.content_sha256,
+                reference_count=claim.reference_count,
+            ))
+
+        return ArtifactCleanupPlan(
+            session_id=self.session_dir.name,
+            planned_at=observed_at.isoformat(),
+            policy=active_policy,
+            decisions=tuple(decisions),
+        )
+
+    @staticmethod
+    def _snapshot_matches(
+        decision: ArtifactCleanupDecision,
+        snapshot: os.stat_result,
+    ) -> bool:
+        return (
+            decision.byte_size == snapshot.st_size
+            and decision.snapshot_mtime_ns == snapshot.st_mtime_ns
+            and decision.snapshot_device == snapshot.st_dev
+            and decision.snapshot_inode == snapshot.st_ino
+        )
+
+    def apply_cleanup(
+        self,
+        plan: ArtifactCleanupPlan,
+        *,
+        claims: Sequence[ArtifactRetentionClaim] | None = None,
+        now: datetime | None = None,
+    ) -> ArtifactCleanupReport:
+        """Apply deletions after rechecking current claims and file identity."""
+
+        if not isinstance(plan, ArtifactCleanupPlan):
+            raise ArtifactRetentionError("cleanup requires an ArtifactCleanupPlan")
+        if plan.session_id != self.session_dir.name:
+            raise ArtifactRetentionError("cleanup plan belongs to a different session")
+        applied_at = _aware_utc(now)
+        has_deletions = any(
+            decision.status is ArtifactCleanupStatus.PLANNED_DELETE
+            for decision in plan.decisions
+        )
+        if has_deletions and not plan.policy.dry_run and claims is None:
+            raise ArtifactRetentionError(
+                "current retention claims are required when applying deletions"
+            )
+        current_claims, active_claims = self._validated_claims(
+            claims or (),
+            now=applied_at,
+        )
+        outcomes: list[ArtifactCleanupDecision] = []
+        for decision in plan.decisions:
+            if decision.status is not ArtifactCleanupStatus.PLANNED_DELETE:
+                outcomes.append(decision)
+                continue
+            if plan.policy.dry_run:
+                outcomes.append(decision)
+                continue
+            current_claim = current_claims.get(decision.filename)
+            if current_claim is not None and (
+                current_claim.content_sha256 != decision.content_sha256
+            ):
+                outcomes.append(replace(
+                    decision,
+                    status=ArtifactCleanupStatus.RETAINED_CORRUPT,
+                    reason="current_retention_claim_digest_mismatch",
+                    reference_count=current_claim.reference_count,
+                ))
+                continue
+            if decision.filename in active_claims:
+                outcomes.append(replace(
+                    decision,
+                    status=ArtifactCleanupStatus.RETAINED_REFERENCED,
+                    reason="active_claim_added_after_cleanup_plan",
+                    reference_count=active_claims[decision.filename].reference_count,
+                ))
+                continue
+            if not _ARTIFACT_FILENAME_PATTERN.fullmatch(decision.filename):
+                outcomes.append(replace(
+                    decision,
+                    status=ArtifactCleanupStatus.DENIED,
+                    reason="cleanup_plan_filename_not_owned",
+                ))
+                continue
+            candidate = self.tool_results_dir / decision.filename
+            try:
+                if candidate.is_symlink():
+                    raise ArtifactAccessError("symbolic link changed after planning")
+                owned_path = self._owned_path(candidate)
+                before_hash = owned_path.stat()
+                if not owned_path.is_file() or not self._snapshot_matches(
+                    decision,
+                    before_hash,
+                ):
+                    raise ArtifactIntegrityError("artifact snapshot changed")
+                digest = self._stream_sha256(owned_path)
+                after_hash = owned_path.stat()
+                if (
+                    digest != decision.content_sha256
+                    or not self._snapshot_matches(decision, after_hash)
+                ):
+                    raise ArtifactIntegrityError("artifact changed while hashing")
+                owned_path.unlink()
+            except FileNotFoundError:
+                outcomes.append(replace(
+                    decision,
+                    status=ArtifactCleanupStatus.ALREADY_MISSING,
+                    reason="artifact_already_missing",
+                ))
+            except PermissionError:
+                outcomes.append(replace(
+                    decision,
+                    status=ArtifactCleanupStatus.DENIED,
+                    reason="artifact_delete_denied",
+                ))
+            except (ArtifactAccessError, ArtifactIntegrityError, OSError):
+                outcomes.append(replace(
+                    decision,
+                    status=ArtifactCleanupStatus.RACE_DETECTED,
+                    reason="artifact_changed_after_cleanup_plan",
+                ))
+            else:
+                outcomes.append(replace(
+                    decision,
+                    status=ArtifactCleanupStatus.DELETED,
+                    reason="expired_unreferenced_artifact_deleted",
+                ))
+        return ArtifactCleanupReport(
+            session_id=self.session_dir.name,
+            planned_at=plan.planned_at,
+            applied_at=applied_at.isoformat(),
+            dry_run=plan.policy.dry_run,
+            decisions=tuple(outcomes),
+        )
+
+    def cleanup_artifacts(
+        self,
+        claims: Sequence[ArtifactRetentionClaim] = (),
+        *,
+        policy: ArtifactCleanupPolicy | None = None,
+        now: datetime | None = None,
+    ) -> ArtifactCleanupReport:
+        """Plan then apply one cleanup pass; defaults to a safe dry run."""
+
+        plan = self.plan_cleanup(claims, policy=policy, now=now)
+        return self.apply_cleanup(plan, claims=claims, now=now)
 
     def externalize(
         self,

--- a/s13_output_externalization/images/output-externalization.svg
+++ b/s13_output_externalization/images/output-externalization.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 660" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif">
   <defs>
     <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0,0 L10,5 L0,10 Z" fill="#1a73e8"/>
@@ -20,11 +20,11 @@
   </defs>
 
   <!-- Background -->
-  <rect width="800" height="560" fill="#f8f9fa"/>
+  <rect width="800" height="660" fill="#f8f9fa"/>
 
   <!-- Title -->
   <text x="400" y="38" text-anchor="middle" font-size="24" font-weight="700" fill="#202124">工具输出外部化 (Output Swap)</text>
-  <text x="400" y="60" text-anchor="middle" font-size="13" fill="#5f6368">完整正文归 Artifact；Context 与 Memory 只保存有来源的有界引用</text>
+  <text x="400" y="60" text-anchor="middle" font-size="13" fill="#5f6368">完整正文归 Artifact；Context / Memory 留有界引用；GC 按租约与 digest 回收孤儿</text>
 
   <!-- ===== LEFT: 上下文窗口 (RAM) ===== -->
   <rect x="40" y="110" width="280" height="200" rx="12" fill="url(#ram-grad)" stroke="#1a73e8" stroke-width="2"/>
@@ -113,4 +113,19 @@
   <text x="430" y="469" font-size="14" font-weight="700" fill="#1a73e8">Bash 输出 ≤ 30K chars</text>
   <text x="430" y="489" font-size="12" fill="#5f6368">→ 直接进入当前上下文</text>
   <text x="430" y="508" font-size="11" fill="#5f6368">仍不等于自动写入长期 Memory</text>
+
+  <!-- ===== Reference-aware lifecycle ===== -->
+  <rect x="40" y="555" width="720" height="88" rx="12" fill="#ffffff" stroke="#f9ab00" stroke-width="1.5"/>
+  <text x="60" y="577" font-size="13" font-weight="700" fill="#a15c00">引用感知 GC（session close / scheduled cleanup）</text>
+  <rect x="60" y="588" width="190" height="38" rx="7" fill="#fff7e0" stroke="#f9ab00"/>
+  <text x="155" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#a15c00">RetentionClaim</text>
+  <text x="155" y="618" text-anchor="middle" font-size="9" fill="#5f6368">source ID + digest + lease</text>
+  <line x1="250" y1="607" x2="292" y2="607" stroke="#f9ab00" stroke-width="2" marker-end="url(#arrow-green)"/>
+  <rect x="300" y="588" width="200" height="38" rx="7" fill="#e8f0fe" stroke="#1a73e8"/>
+  <text x="400" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#174ea6">plan → snapshot → recheck</text>
+  <text x="400" y="618" text-anchor="middle" font-size="9" fill="#5f6368">identity + mtime + size + SHA-256</text>
+  <line x1="500" y1="607" x2="542" y2="607" stroke="#1a73e8" stroke-width="2" marker-end="url(#arrow-blue)"/>
+  <rect x="550" y="588" width="190" height="38" rx="7" fill="#e6f4ea" stroke="#34a853"/>
+  <text x="645" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#137333">retain / delete orphan</text>
+  <text x="645" y="618" text-anchor="middle" font-size="9" fill="#5f6368">异常或竞态一律 fail-closed</text>
 </svg>

--- a/tests/test_layered_memory_walkthrough.py
+++ b/tests/test_layered_memory_walkthrough.py
@@ -46,6 +46,7 @@ def test_layered_memory_walkthrough_is_keyless_and_restart_safe(
     assert result.returncode == 0, result.stdout[-4_000:]
     assert "RESULT: OK" in result.stdout
     assert "created -> unchanged; bob empty=True" in result.stdout
+    assert "referenced retained=1; expired orphan deleted=1" in result.stdout
     assert "durable preserved=True" in result.stdout
     assert "sources verified=2" in result.stdout
 
@@ -69,10 +70,20 @@ def test_layered_memory_walkthrough_is_keyless_and_restart_safe(
     )
 
     # Memory receives bounded artifact metadata, never the externalized body.
-    artifact_reference = manifest["layers"]["artifact"]
+    artifact_layer = manifest["layers"]["artifact"]
+    artifact_reference = artifact_layer["reference"]
     assert "content" not in artifact_reference
     assert len(artifact_reference["content_sha256"]) == 64
     assert Path(artifact_reference["artifact_path"]).stat().st_size > 30_000
+    assert artifact_layer["cleanup"]["counts"] == {
+        "deleted": 1,
+        "retained_referenced": 1,
+    }
+    assert artifact_layer["orphan_resolution"]["status"] == "missing"
+    assert all(
+        "artifact_path" not in decision
+        for decision in artifact_layer["cleanup"]["decisions"]
+    )
 
     compaction = manifest["layers"]["compaction"]
     assert compaction["applied_layers"] == [

--- a/tests/test_output_externalization.py
+++ b/tests/test_output_externalization.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import json
+import os
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -125,3 +128,260 @@ def test_invalid_summary_fails_before_creating_artifact(s13, tmp_path: Path) -> 
         externalizer.externalize("large output", "search", summary="  ")
 
     assert list(externalizer.tool_results_dir.iterdir()) == []
+
+
+def _set_artifact_age(path: Path, *, now: datetime, age_seconds: int) -> None:
+    observed = now.timestamp() - age_seconds
+    os.utime(path, (observed, observed))
+
+
+def test_cleanup_retains_memory_reference_and_deletes_expired_orphan(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 27, 12, tzinfo=timezone.utc)
+    externalizer = s13.ToolResultExternalizer(tmp_path / "retention-session")
+    referenced = externalizer.externalize(
+        "durable build evidence",
+        "search",
+        summary="Referenced build evidence.",
+    ).artifact
+    orphan = externalizer.externalize(
+        "temporary diagnostic output",
+        "search",
+        summary="Temporary diagnostic output.",
+    ).artifact
+    _set_artifact_age(referenced.path, now=now, age_seconds=7_200)
+    _set_artifact_age(orphan.path, now=now, age_seconds=7_200)
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(
+        referenced.for_memory(),
+        reference_count=2,
+    )
+    policy = s13.ArtifactCleanupPolicy(
+        orphan_ttl_seconds=3_600,
+        dry_run=False,
+    )
+
+    plan = externalizer.plan_cleanup((claim,), policy=policy, now=now)
+    planned = {decision.filename: decision for decision in plan.decisions}
+    assert planned[referenced.path.name].status is (
+        s13.ArtifactCleanupStatus.RETAINED_REFERENCED
+    )
+    assert planned[referenced.path.name].reference_count == 2
+    assert planned[orphan.path.name].status is (
+        s13.ArtifactCleanupStatus.PLANNED_DELETE
+    )
+    assert str(tmp_path) not in json.dumps(plan.to_dict(), sort_keys=True)
+
+    report = externalizer.apply_cleanup(plan, claims=(claim,), now=now)
+    assert report.counts == {
+        "retained_referenced": 1,
+        "deleted": 1,
+    }
+    assert referenced.path.read_text(encoding="utf-8") == "durable build evidence"
+    assert not orphan.path.exists()
+
+
+def test_cleanup_dry_run_ttl_and_deletion_limit_are_deterministic(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 27, 12, tzinfo=timezone.utc)
+    externalizer = s13.ToolResultExternalizer(tmp_path / "policy-session")
+    old_first = externalizer.externalize(
+        "old first",
+        "search",
+        summary="Old first artifact.",
+    ).artifact
+    old_second = externalizer.externalize(
+        "old second",
+        "search",
+        summary="Old second artifact.",
+    ).artifact
+    recent = externalizer.externalize(
+        "recent",
+        "search",
+        summary="Recent artifact.",
+    ).artifact
+    for artifact in (old_first, old_second):
+        _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    _set_artifact_age(recent.path, now=now, age_seconds=30)
+
+    policy = s13.ArtifactCleanupPolicy(
+        orphan_ttl_seconds=60,
+        max_deletions=1,
+        dry_run=True,
+    )
+    report = externalizer.cleanup_artifacts(policy=policy, now=now)
+    statuses = {
+        decision.filename: decision.status
+        for decision in report.decisions
+    }
+
+    assert statuses[old_first.path.name] is s13.ArtifactCleanupStatus.PLANNED_DELETE
+    assert statuses[old_second.path.name] is s13.ArtifactCleanupStatus.RETAINED_LIMIT
+    assert statuses[recent.path.name] is s13.ArtifactCleanupStatus.RETAINED_RECENT
+    assert all(artifact.path.exists() for artifact in (old_first, old_second, recent))
+
+
+def test_expired_claim_can_be_collected_but_missing_active_claim_is_reported(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 27, 12, tzinfo=timezone.utc)
+    externalizer = s13.ToolResultExternalizer(tmp_path / "lease-session")
+    artifact = externalizer.externalize(
+        "expired lease body",
+        "search",
+        summary="Expired lease artifact.",
+    ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    expired = s13.ArtifactRetentionClaim.from_memory_reference(
+        artifact.for_memory(),
+        retain_until=(now - timedelta(seconds=1)).isoformat(),
+    )
+    missing_digest = hashlib.sha256(b"missing artifact").hexdigest()
+    missing = s13.ArtifactRetentionClaim(
+        source_id=(
+            "artifact:lease-session:tool_result_999.txt:"
+            f"{missing_digest[:12]}"
+        ),
+        content_sha256=missing_digest,
+    )
+
+    plan = externalizer.plan_cleanup(
+        (expired, missing),
+        policy=s13.ArtifactCleanupPolicy(
+            orphan_ttl_seconds=60,
+            dry_run=False,
+        ),
+        now=now,
+    )
+    statuses = {decision.filename: decision.status for decision in plan.decisions}
+    assert statuses[artifact.path.name] is s13.ArtifactCleanupStatus.PLANNED_DELETE
+    assert statuses["tool_result_999.txt"] is (
+        s13.ArtifactCleanupStatus.MISSING_REFERENCED
+    )
+
+    report = externalizer.apply_cleanup(plan, claims=(expired, missing), now=now)
+    assert report.counts == {"deleted": 1, "missing_referenced": 1}
+    assert not artifact.path.exists()
+
+
+def test_cleanup_retains_artifact_when_claim_digest_disagrees(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 27, 12, tzinfo=timezone.utc)
+    externalizer = s13.ToolResultExternalizer(tmp_path / "corrupt-session")
+    artifact = externalizer.externalize(
+        "original evidence",
+        "search",
+        summary="Evidence protected by a retention claim.",
+    ).artifact
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    artifact.path.write_text("tampered evidence", encoding="utf-8")
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+
+    report = externalizer.cleanup_artifacts(
+        (claim,),
+        policy=s13.ArtifactCleanupPolicy(
+            orphan_ttl_seconds=60,
+            dry_run=False,
+        ),
+        now=now,
+    )
+
+    assert report.counts == {"retained_corrupt": 1}
+    assert artifact.path.read_text(encoding="utf-8") == "tampered evidence"
+
+
+def test_cleanup_rechecks_claims_added_after_planning(s13, tmp_path: Path) -> None:
+    now = datetime(2026, 8, 27, 12, tzinfo=timezone.utc)
+    externalizer = s13.ToolResultExternalizer(tmp_path / "late-claim-session")
+    artifact = externalizer.externalize(
+        "evidence claimed after planning",
+        "search",
+        summary="Evidence that gains an owner before apply.",
+    ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    policy = s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False)
+    plan = externalizer.plan_cleanup(policy=policy, now=now)
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+
+    with pytest.raises(s13.ArtifactRetentionError, match="current retention claims"):
+        externalizer.apply_cleanup(plan, now=now)
+
+    report = externalizer.apply_cleanup(plan, claims=(claim,), now=now)
+    assert report.counts == {"retained_referenced": 1}
+    assert artifact.path.exists()
+
+
+def test_cleanup_rechecks_digest_and_is_idempotent(s13, tmp_path: Path) -> None:
+    now = datetime(2026, 8, 27, 12, tzinfo=timezone.utc)
+    externalizer = s13.ToolResultExternalizer(tmp_path / "race-session")
+    raced = externalizer.externalize(
+        "original-bytes",
+        "search",
+        summary="Race detection artifact.",
+    ).artifact
+    _set_artifact_age(raced.path, now=now, age_seconds=7_200)
+    policy = s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False)
+    plan = externalizer.plan_cleanup(policy=policy, now=now)
+    deletion = next(
+        decision
+        for decision in plan.decisions
+        if decision.status is s13.ArtifactCleanupStatus.PLANNED_DELETE
+    )
+    raced.path.write_text("replaced-bytes", encoding="utf-8")
+    snapshot = raced.path.stat()
+    os.utime(
+        raced.path,
+        ns=(snapshot.st_atime_ns, deletion.snapshot_mtime_ns),
+    )
+
+    raced_report = externalizer.apply_cleanup(plan, claims=(), now=now)
+    assert raced_report.counts == {"race_detected": 1}
+    assert raced.path.exists()
+
+    idempotent_externalizer = s13.ToolResultExternalizer(
+        tmp_path / "idempotent-session"
+    )
+    safe = idempotent_externalizer.externalize(
+        "safe orphan",
+        "search",
+        summary="Safe orphan artifact.",
+    ).artifact
+    _set_artifact_age(safe.path, now=now, age_seconds=7_200)
+    safe_plan = idempotent_externalizer.plan_cleanup(policy=policy, now=now)
+    first = idempotent_externalizer.apply_cleanup(safe_plan, claims=(), now=now)
+    second = idempotent_externalizer.apply_cleanup(safe_plan, claims=(), now=now)
+    assert first.counts["deleted"] == 1
+    assert second.counts["already_missing"] == 1
+
+
+def test_cleanup_rejects_cross_session_claims_and_symlink_escape(
+    s13, tmp_path: Path
+) -> None:
+    externalizer = s13.ToolResultExternalizer(tmp_path / "owned-session")
+    digest = hashlib.sha256(b"other session").hexdigest()
+    cross_session = s13.ArtifactRetentionClaim(
+        source_id=f"artifact:other-session:tool_result_001.txt:{digest[:12]}",
+        content_sha256=digest,
+    )
+    with pytest.raises(s13.ArtifactRetentionError, match="different artifact session"):
+        externalizer.plan_cleanup((cross_session,))
+    with pytest.raises(s13.ArtifactRetentionError, match="path-free"):
+        s13.parse_artifact_source_id(
+            f"artifact:../outside:tool_result_001.txt:{digest[:12]}"
+        )
+
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside owner", encoding="utf-8")
+    link = externalizer.tool_results_dir / "tool_result_001.txt"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        pytest.skip("file symlinks are unavailable on this platform")
+    plan = externalizer.plan_cleanup(
+        policy=s13.ArtifactCleanupPolicy(orphan_ttl_seconds=0, dry_run=False)
+    )
+    assert plan.decisions[0].status is s13.ArtifactCleanupStatus.DENIED
+    externalizer.apply_cleanup(plan)
+    assert outside.read_text(encoding="utf-8") == "outside owner"


### PR DESCRIPTION
## Summary

- add path-free retention claims and strict artifact source parsing
- add deterministic dry-run planning plus reference-aware, race-checked cleanup
- revalidate the current claim view before apply so late references remain protected
- extend the layered memory walkthrough, chapter diagram, documentation, and regression coverage

## Validation

- `python3 -m pytest -q tests/test_output_externalization.py tests/test_layered_memory_walkthrough.py` (14 passed)
- full pytest suite passed locally except the workspace-shape image-count test affected by pre-existing untracked `tmp/` assets
- syntax, lesson interactivity, SVG XML, clean-room, public-doc, and image-specificity checks passed