### PR TITLE
feat(s13): add crash-recoverable retention lease journal

### DIFF
--- a/examples/layered_memory_walkthrough/README.md
+++ b/examples/layered_memory_walkthrough/README.md
@@ -16,7 +16,8 @@ flowchart LR
   U["S11 keyed user preference"] --> I["scope isolation"]
   A["S13 Artifact"] --> P["bounded pointer + digest"]
   P --> L["retention claim"]
-  L --> G["plan/apply cleanup"]
+  L --> J["lease journal<br/>prepare → publish → commit"]
+  J --> G["restart fold + locked cleanup"]
   G --> K["referenced retained / orphan deleted"]
   R --> F["fresh-process recovery"]
   D --> F
@@ -43,6 +44,7 @@ flowchart LR
 | Recall hit | S12 查询结果 | 单 query | 是；它只是带 source 和 score 的候选视图 |
 | Artifact | S13 大结果证据 | session artifact | 原文件不允许；Prompt 只留摘要和指针 |
 | Retention claim | S13 清理租约 | Memory 引用期 | 无正文、无路径；只保护匹配 source/digest 的 Artifact |
+| Lease journal | S13 引用事务证据 | session、跨进程 | 不允许改写；只忽略未换行的崩溃尾部 |
 | Compacted messages | S14 Prompt 视图 | 单次或少数几次模型调用 | 允许；durable state 必须走无损旁路 |
 | Source resolution | S14 本轮核验视图 | 单次 Prompt 组装 | 不复用旧状态；每轮从 owner 重新核验 |
 
@@ -68,7 +70,7 @@ python3 examples/layered_memory_walkthrough/code.py --home /tmp/layered-memory
 [3] Workspace log and distill
 [4] User preference dedup and isolation
 [5] Query-scoped recall
-[6] Reference-aware artifact cleanup
+[6] Crash-recovered artifact leases and cleanup
 [7] Compaction boundary — sources verified=2
 RESULT: OK — layered memory boundaries survived compaction and restart.
 ```
@@ -77,11 +79,11 @@ RESULT: OK — layered memory boundaries survived compaction and restart.
 
 1. S09 写入两条 append-only transcript event，只显式选择其中一条 assistant message 作为 Memory candidate。candidate 只有稳定 source ID、摘要和选择原因，不复制整个 Transcript。
 2. S13 把约 49KB 的工具结果外部化。Artifact 文件保存原文，后续层只接收 bounded summary、路径、SHA-256 和 source metadata。
-3. S10 将同一项目决策作为两条独立证据追加到 daily log。`DistillPolicy` 根据 repeat threshold 把它们合并成一条 curated entry，同时保留两个 evidence ID；Artifact 结果作为 outcome 只留引用，不冒充稳定规则。
+3. S10 将同一项目决策作为两条独立证据追加到 daily log。`DistillPolicy` 根据 repeat threshold 把它们合并成一条 curated entry，同时保留两个 evidence ID；写入 Artifact outcome 前，S13 lease journal 先 fsync `prepared`，Memory 写入成功后再追加 `committed`。
 4. S11 为 Alice 写入 keyed preference。相同 key/value 的第二次写入返回 `unchanged`，不增加 revision；Bob 使用同一 state root 仍得到空偏好，证明 user scope 隔离。
 5. S12 把 S09 candidate 写成 source-bearing conversation record，再为一个自包含 query 生成带 rank、score 和 provenance 的 RecallHit。Recall 不修改 Workspace 或 User Memory。
 6. walkthrough 丢弃所有对象并用相同路径创建新实例，分别恢复 Transcript、Workspace、User、Remote Store 和 Artifact。随后根据恢复结果重建 S14 `DurableContextState`。
-7. fresh S13 externalizer 从 Memory reference 生成无路径 retention claim，再用两阶段 cleanup 保留被引用的旧 Artifact、删除同龄但无 owner 的孤儿；report 不复制正文或物理路径。
+7. fresh S13 journal 从 append-only 记录恢复 committed claim；fresh externalizer 在 journal 锁内重新 fold 当前引用，再用两阶段 cleanup 保留被引用的旧 Artifact、删除同龄但无 owner 的孤儿。recovery/report 都不复制正文或物理路径。
 8. 为了在小 fixture 中确定性触发 S14，代码临时降低当前模块实例的压缩阈值，并在 `finally` 中恢复。对抗性 summarizer 会谎称“任务已完成”，测试要求错误只能进入 conversation summary，不能进入 durable context。
 9. 压缩完成后创建新的 `SourcePointerResolver`，从可信 Transcript / Artifact 根重新核验两个 durable pointer，并确认已清理孤儿得到 `missing`。Prompt 只接收 status 与 evidence hash，bounded excerpt 不进入 durable context，manifest 也不复制正文。
 
@@ -108,9 +110,9 @@ online agent_loop 真正调用模型
 
 运行目录里的 `layered_memory_manifest.json` 分三部分：
 
-- `checks`：十一个布尔不变量，包括去重、隔离、来源恢复、引用感知 cleanup、Artifact digest、source pointer 核验和 compaction 边界。
-- `layers`：每一层的可观察结果，例如 distill report、RecallHit、ArtifactMemoryReference、不含路径的 cleanup report、压缩前后 token、触发层和不含 excerpt 的 source resolutions。
-- `artifacts`：Transcript JSONL、Workspace log/curated view、User preferences、Remote store 和 tool result 的真实路径。
+- `checks`：十一个布尔不变量，包括去重、隔离、lease 恢复、引用感知 cleanup、Artifact digest、source pointer 核验和 compaction 边界。
+- `layers`：每一层的可观察结果，例如 distill report、RecallHit、ArtifactMemoryReference、不含路径的 lease recovery/cleanup report、压缩前后 token、触发层和不含 excerpt 的 source resolutions。
+- `artifacts`：Transcript JSONL、Workspace log/curated view、User preferences、Remote store、retention journal 和 tool result 的真实路径。
 
 Manifest 只是一份验收报告，不是新的 Memory 真源。需要核验时仍应打开对应 owner 的文件。
 
@@ -120,6 +122,7 @@ Manifest 只是一份验收报告，不是新的 Memory 真源。需要核验时
 - **重复不等于多存一份。** Workspace 用 evidence IDs 合并重复事实；User preference 用稳定 key 返回 `unchanged`。
 - **同一 state root 不等于同一用户。** Alice 和 Bob 的 scope digest 不同，不能互读 canonical state。
 - **引用不等于复制。** Memory-facing Artifact reference 没有 `content` 字段，大结果仍归 Artifact 文件所有。
+- **发布不等于立即可信。** lease intent 必须先于 Memory 引用落盘；重启遇到 pending prepare 时默认保留 Artifact，等待 owner 对账。
 - **清理不等于删除整个 session。** active claim 只按 source ID + 完整 digest 保护对应证据；达到 TTL 的无引用孤儿才能在重验后删除。
 - **恢复不等于复用旧对象。** walkthrough 明确创建 fresh store instances，再从磁盘重建视图。
 - **摘要不拥有事实。** S14 只压缩 messages 副本，source-bearing facts 和 pending items 单独渲染。

--- a/examples/layered_memory_walkthrough/code.py
+++ b/examples/layered_memory_walkthrough/code.py
@@ -182,6 +182,10 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         summary="Build verification completed for the layered memory walkthrough.",
     )
     artifact_memory = externalized.artifact.for_memory()
+    retention_journal = chapters.s13.ArtifactRetentionJournal(artifact_session)
+    artifact_claim = chapters.s13.ArtifactRetentionClaim.from_memory_reference(
+        artifact_memory,
+    )
     orphaned_artifact = externalizer.externalize(
         "temporary diagnostic output",
         "search",
@@ -217,18 +221,24 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         recorded_at=recorded_at,
         fact_id="workspace-decision-2",
     )
-    workspace.append_daily_log(
-        artifact_memory.summary,
-        kind=chapters.s10.FactKind.OUTCOME,
-        importance=3,
-        source="artifact",
-        evidence={
-            "source_id": artifact_memory.source.source_id,
-            "artifact_path": artifact_memory.artifact_path,
-            "content_sha256": artifact_memory.content_sha256,
-        },
-        recorded_at=recorded_at,
-        fact_id="workspace-artifact-1",
+    lease_transaction, _ = retention_journal.publish_reference(
+        artifact_claim,
+        lambda: workspace.append_daily_log(
+            artifact_memory.summary,
+            kind=chapters.s10.FactKind.OUTCOME,
+            importance=3,
+            source="artifact",
+            evidence={
+                "source_id": artifact_memory.source.source_id,
+                "artifact_path": artifact_memory.artifact_path,
+                "content_sha256": artifact_memory.content_sha256,
+            },
+            recorded_at=recorded_at,
+            fact_id="workspace-artifact-1",
+        ),
+        transaction_id="workspace-artifact-reference-1",
+        prepared_at=recorded_at,
+        committed_at=recorded_at,
     )
     distill = workspace.distill(
         policy=chapters.s10.DistillPolicy(
@@ -306,20 +316,19 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         as_of=as_of,
     )
     restarted_externalizer = chapters.s13.ToolResultExternalizer(artifact_session)
-    cleanup_claim = chapters.s13.ArtifactRetentionClaim.from_memory_reference(
-        artifact_memory,
-    )
-    cleanup_plan = restarted_externalizer.plan_cleanup(
-        (cleanup_claim,),
+    restarted_journal = chapters.s13.ArtifactRetentionJournal(artifact_session)
+    lease_recovery = restarted_journal.recover(now=as_of)
+    cleanup_plan = restarted_externalizer.plan_cleanup_from_journal(
+        restarted_journal,
         policy=chapters.s13.ArtifactCleanupPolicy(
             orphan_ttl_seconds=24 * 60 * 60,
             dry_run=False,
         ),
         now=as_of,
     )
-    cleanup_report = restarted_externalizer.apply_cleanup(
+    cleanup_report = restarted_externalizer.apply_cleanup_from_journal(
         cleanup_plan,
-        claims=(cleanup_claim,),
+        restarted_journal,
         now=as_of,
     )
     recovered_artifact_head = restarted_externalizer.read_artifact(
@@ -329,8 +338,8 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
     )
     _print_stage(
         6,
-        "Reference-aware artifact cleanup",
-        "referenced retained=1; expired orphan deleted=1",
+        "Crash-recovered artifact leases and cleanup",
+        "lease recovered=1; referenced retained=1; expired orphan deleted=1",
     )
 
     durable_state = chapters.s14.DurableContextState(
@@ -442,7 +451,11 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
             and len(artifact_memory.content_sha256) == 64
         ),
         "artifact_cleanup_preserved_references": (
-            cleanup_report.counts == {
+            lease_recovery.claims == (artifact_claim,)
+            and lease_recovery.pending_transaction_ids == ()
+            and lease_recovery.states[0].transaction.transaction_id
+            == lease_transaction.transaction_id
+            and cleanup_report.counts == {
                 "retained_referenced": 1,
                 "deleted": 1,
             }
@@ -463,6 +476,7 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         "user_preferences": str(alice.preferences_path),
         "remote_memory": str(remote_path),
         "tool_result": artifact_memory.artifact_path,
+        "retention_journal": str(retention_journal.path),
     }
     layers = {
         "transcript": {
@@ -486,6 +500,7 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         },
         "artifact": {
             "reference": artifact_memory.to_dict(),
+            "lease_recovery": lease_recovery.to_dict(),
             "cleanup": cleanup_report.to_dict(),
             "orphan_resolution": orphan_resolution.to_dict(
                 include_excerpt=False,

--- a/examples/layered_memory_walkthrough/images/layered-memory.svg
+++ b/examples/layered_memory_walkthrough/images/layered-memory.svg
@@ -36,9 +36,9 @@
   <text x="55" y="390" font-size="11" fill="#475569">user scope · explicit mutation</text>
 
   <rect x="35" y="422" width="270" height="82" rx="12" fill="#ffedd5" stroke="#ea580c" stroke-width="2"/>
-  <text x="55" y="449" font-size="14" font-weight="700" fill="#9a3412">S13 Artifact</text>
-  <text x="55" y="472" font-size="11" fill="#475569">immutable large tool result</text>
-  <text x="55" y="490" font-size="11" fill="#475569">path · SHA-256 · source</text>
+  <text x="55" y="449" font-size="14" font-weight="700" fill="#9a3412">S13 Artifact + lease journal</text>
+  <text x="55" y="472" font-size="11" fill="#475569">immutable result + append-only leases</text>
+  <text x="55" y="490" font-size="11" fill="#475569">path · SHA-256 · prepare/commit</text>
 
   <!-- Policies and derived views -->
   <line x1="305" y1="163" x2="390" y2="163" stroke="#2563eb" stroke-width="2" marker-end="url(#arrow-blue)"/>
@@ -61,9 +61,9 @@
 
   <line x1="305" y1="463" x2="390" y2="463" stroke="#ea580c" stroke-width="2" marker-end="url(#arrow-orange)"/>
   <rect x="400" y="422" width="270" height="82" rx="12" fill="#ffffff" stroke="#ea580c" stroke-width="2"/>
-  <text x="420" y="449" font-size="14" font-weight="700" fill="#9a3412">Bounded Memory reference</text>
-  <text x="420" y="472" font-size="11" fill="#475569">summary + pointer + digest</text>
-  <text x="420" y="490" font-size="11" fill="#475569">raw content stays in artifact file</text>
+  <text x="420" y="449" font-size="14" font-weight="700" fill="#9a3412">Crash-safe reference publish</text>
+  <text x="420" y="472" font-size="11" fill="#475569">prepare → Memory write → commit</text>
+  <text x="420" y="490" font-size="11" fill="#475569">locked recovery protects pending lease</text>
 
   <!-- Restart boundary and recovery -->
   <line x1="710" y1="112" x2="710" y2="520" stroke="#94a3b8" stroke-width="2" stroke-dasharray="7 7"/>
@@ -86,7 +86,7 @@
   <text x="795" y="339" font-size="12" font-weight="700" fill="#166534">Recall</text>
   <text x="900" y="339" font-size="11" fill="#475569">source-bearing hit rebuilt</text>
   <text x="795" y="385" font-size="12" font-weight="700" fill="#166534">Artifact</text>
-  <text x="900" y="385" font-size="11" fill="#475569">ownership + digest verified</text>
+  <text x="900" y="385" font-size="11" fill="#475569">lease fold + digest + orphan GC</text>
   <line x1="795" y1="410" x2="1035" y2="410" stroke="#bbf7d0" stroke-width="2"/>
   <text x="915" y="440" text-anchor="middle" font-size="13" font-weight="700" fill="#166534">Reconstruct DurableContextState</text>
   <text x="915" y="465" text-anchor="middle" font-size="11" fill="#475569">confirmed fact + pending artifact review</text>

--- a/s13_output_externalization/README.md
+++ b/s13_output_externalization/README.md
@@ -19,8 +19,9 @@ flowchart LR
     C --> F["ArtifactReference<br/>digest + provenance"]
     F -. "later policy" .-> G["Memory Reference<br/>summary + pointer, no body"]
     G --> H["ArtifactRetentionClaim<br/>source ID + digest + lease"]
+    H --> L["Lease Journal<br/>prepared → committed → released"]
     C --> I["plan_cleanup → snapshot"]
-    H --> I
+    L --> I
     I --> J["retain referenced / recent<br/>delete expired orphan"]
 ```
 
@@ -36,6 +37,7 @@ flowchart LR
 - 为 artifact 生成稳定 source ID、摘要、来源工具、时间与 SHA-256，避免它变成不可审计的匿名文件。
 - Memory 只能接收 `ArtifactMemoryReference`，保留必要摘要与可检索指针，不复制大结果正文。
 - 用无路径 `ArtifactRetentionClaim` 把 Memory 引用投影为清理租约；物理路径始终由 S13 的可信 session root 决定。
+- 在 Memory 发布引用前先把 lease intent 追加并 fsync 到 journal；重启后从 journal 恢复当前 claim view。
 - 清理分成 plan/apply 两阶段，执行前重新核验文件 identity、mtime、大小与 SHA-256；变化时 fail-closed。
 - 模拟按需读取片段, 类似缺页中断。
 - 为 s14 的压缩减轻压力。
@@ -49,6 +51,8 @@ flowchart LR
 - 把 pointer 中的 head/tail 预览原样写进 Memory，本质上仍在复制可能巨大或敏感的工具正文。
 - 会话结束就删除整个 `tool-results/`，会让仍被 Workspace/User Memory 引用的证据立即悬空。
 - 直接相信 Memory 中的 `artifact_path` 做删除，会把不可信持久化数据变成任意文件删除入口。
+- 先发布 Memory 引用、后记录进程内 claim，会在崩溃窗口里产生无法证明归属的 Artifact。
+- 删除 Memory 引用前先释放 lease，会在相反的崩溃窗口里留下仍可访问但已失去保护的指针。
 - 扫描到未知文件、符号链接、digest 冲突或竞态仍继续删除，违背证据清理的 fail-closed 边界。
 
 ## 问题
@@ -215,6 +219,41 @@ ArtifactMemoryReference
 
 `ArtifactRetentionClaim` 刻意没有路径。清理器只解析 `artifact:<session>:<filename>:<digest>`，并要求 session 与当前 `ToolResultExternalizer` 一致；文件最终位置只能从可信 `session_dir/tool-results` 推导。跨 session claim、路径分量和不匹配 digest 在删除前就会被拒绝。
 
+#### Crash-recoverable lease journal
+
+进程内 claim 无法独自跨过崩溃边界。`ArtifactRetentionJournal` 在 session 根写入 append-only `retention-leases.jsonl`，每条记录包含递增 sequence、前一条记录 hash 和自身 SHA-256。读取器只忽略没有换行的最后一条残缺记录；完整坏行、sequence 断裂、跨 session 记录、intent 改写或 hash-chain 断裂都会让恢复失败，GC 不会把损坏日志当成“没有引用”。
+
+引用发布协议按以下顺序执行：
+
+```text
+1. PREPARED  ── append + fsync ──▶ lease intent 已持久化
+2. Memory adapter 发布引用
+3. COMMITTED ── append + fsync ──▶ 引用确认可见
+```
+
+如果步骤 2 正常失败，Harness 追加 `ABORTED`。如果进程在步骤 1 后退出，无论 Memory 写入尚未发生、正在发生，还是已经成功但步骤 3 尚未执行，fresh journal 都把 `PREPARED` 恢复为无过期时间的保护性 claim，并把 transaction ID 放入 `pending_transaction_ids` 等待可信 adapter 对账。它宁可暂时多保留证据，也不会猜测引用不存在。
+
+删除方向采用相反的安全顺序：先由 Memory adapter 删除引用，成功后才追加 `RELEASED`。`remove_reference()` 封装了这个顺序；若删除失败或进程先退出，committed lease 继续保护 Artifact。
+
+```python
+journal = ArtifactRetentionJournal(session_dir)
+claim = ArtifactRetentionClaim.from_memory_reference(memory_reference)
+
+transaction, stored_record = journal.publish_reference(
+    claim,
+    lambda: memory_adapter.append(memory_reference),
+    transaction_id="workspace-artifact-reference-1",
+)
+
+# Memory 删除成功后才释放；异常时 lease 保持 committed。
+journal.remove_reference(
+    transaction.transaction_id,
+    lambda: memory_adapter.remove(memory_reference.source.source_id),
+)
+```
+
+`publish_reference()` 不会自动重放已有 transaction ID。看到已有 `PREPARED` 时，Harness 必须先查询 Memory owner 再显式 `commit()` 或 `abort()`；看到已有 `COMMITTED` 时也不能再次调用 publisher。这样重试不会把“不确定是否已经成功”变成重复 Memory 写入。
+
 清理分成两个阶段：
 
 1. `plan_cleanup()` 只读扫描，流式计算 SHA-256，并冻结 size、mtime、device 与 inode 快照；默认 policy 为 dry-run。
@@ -243,11 +282,12 @@ policy = ArtifactCleanupPolicy(
     max_deletions=100,
     dry_run=False,
 )
-plan = externalizer.plan_cleanup((claim,), policy=policy)
-report = externalizer.apply_cleanup(plan, claims=(claim,))
+journal = ArtifactRetentionJournal(session_dir)
+plan = externalizer.plan_cleanup_from_journal(journal, policy=policy)
+report = externalizer.apply_cleanup_from_journal(plan, journal)
 ```
 
-`reference_count` 由可信 Memory adapter 聚合，不让模型直接声明；claim 缺席或租约过期后，文件仍必须超过 orphan TTL 才有资格删除。非 dry-run apply 若没有显式的当前 claim 视图会直接拒绝，调用方应在同一一致性边界内读取 claims 并执行 apply。cleanup plan/report 只公开 filename、source ID、digest、age 和 reason，不泄露或接受物理路径。这个教学实现把竞态窗口压缩到删除前的 claim 与文件二次校验；生产系统若有并发 writer，还应增加 session lease、目录锁或对象存储条件删除。
+`reference_count` 由可信 Memory adapter 聚合，不让模型直接声明；同一 Artifact 的多个 committed/pending lease 会按完整 digest 聚合。claim 缺席或租约过期后，文件仍必须超过 orphan TTL 才有资格删除。`prepare()` 与 journal-aware cleanup 使用同一排他锁：prepare 在锁内重新核验 typed source、普通文件边界与完整 digest；apply 在锁内重新 fold claims，并把锁保持到文件重验和删除完成。lease 先拿锁则 GC 保留，GC 先删除则 prepare 拒绝发布悬空引用。session 一旦存在 durable journal，旧的 raw-claims cleanup 入口会拒绝执行，避免调用方意外绕过真实 owner。cleanup plan/report 和 recovery report 都不接受物理路径。生产对象存储应把相同契约映射为 generation fence、条件删除或事务，而不是假设本地 advisory lock 能跨主机生效。
 
 ### 按需读取 (Read = 缺页中断)
 
@@ -466,20 +506,25 @@ if (resultSize > CODEBUDDY_TOOL_RESULT_THRESHOLD_KB * 1024) {
    - claim 只携带 typed source ID、完整 digest、引用计数与可选过期时间，不接受 Memory 路径
    - policy 显式控制 orphan TTL、最大删除数量和 dry-run
 
-4. **`ArtifactCleanupPlan` / `ArtifactCleanupReport`** — 两阶段、可审计清理
-   - plan 冻结文件快照并解释每个 retain/delete 决策，不产生写操作
-   - apply 重验归属、identity 与 digest；支持竞态检测和重复执行幂等
+4. **`ArtifactRetentionJournal` / `ArtifactLeaseRecovery`** — 可崩溃恢复的租约所有者
+   - `prepared → committed → released` 与 `prepared → aborted` 显式表达引用发布结果
+   - sequence + hash chain 检查完整记录；只丢弃未换行的崩溃尾部
+   - fresh instance fold journal；pending prepare 默认继续保护证据
 
-5. **`MockLLM`** — 模拟 LLM 的行为
+5. **`ArtifactCleanupPlan` / `ArtifactCleanupReport`** — 两阶段、可审计清理
+   - plan 冻结文件快照并解释每个 retain/delete 决策，不产生写操作
+   - journal-aware apply 在同一排他锁内恢复 claims、重验 identity 与 digest
+
+6. **`MockLLM`** — 模拟 LLM 的行为
    - 按预设脚本生成工具调用
    - 看到外部化指针时，决定是否触发"缺页中断"（调 Read 读完整输出）
 
-6. **Agent 循环** — 集成外部化
+7. **Agent 循环** — 集成外部化
    - 工具执行后检查是否需要外部化
    - 需要则写 artifact + 生成结构化 reference + 替换上下文内容
    - 打印 `[externalize]` 日志，显示节省效果
 
-7. **Demo 场景** — 完整演示
+8. **Demo 场景** — 完整演示
    - 模拟一条产生 1.3MB 输出的 grep 命令
    - 展示外部化前后的上下文大小对比
    - 模拟 agent 需要完整输出时的缺页中断
@@ -509,7 +554,7 @@ python s13_output_externalization/code.py
 ## 练习
 
 1. 当前 `make_pointer` 保留 head 6KB + tail 24KB。如果 agent 最常需要的是输出的中间部分（比如第 40000 行的错误），怎么改进预览策略？提示：考虑基于正则匹配的关键行提取，或分块索引。
-2. 把进程内的 retention claims 持久化为 append-only lease journal，并实现 crash recovery。证明“引用写入成功但 claim 尚未落盘”时清理器仍然 fail-closed。
+2. 为 `pending_transaction_ids` 实现 owner reconciliation adapter：根据 Memory 中的稳定 reference ID 决定 `commit` 或 `abort`，并用 generation fence 证明对账期间的并发更新不会被旧结果覆盖。
 3. 当前的 `should_externalize` 只看输出大小。如果一条命令的输出是 30KB 的随机字符串（对 agent 无用）vs 30KB 的结构化 JSON（每行都有用），应该用不同策略吗？思考：能否让外部化策略感知输出的信息密度？
 
 ---

--- a/s13_output_externalization/code.py
+++ b/s13_output_externalization/code.py
@@ -30,14 +30,23 @@ Usage:
 
 import argparse
 import hashlib
+import json
 import os
 import re
 import tempfile
-from collections.abc import Sequence
+import uuid
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
+from typing import TypeVar
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
 
 # Machine-readable learning path metadata. Tests enforce that every
 # chapter declares what it inherits and what it adds.
@@ -49,6 +58,7 @@ PROGRESSION = {
         "source-bearing artifact references",
         "page-fault reads",
         "reference-aware artifact retention",
+        "crash-recoverable retention lease journal",
     ],
     "preserves": ["context budget mindset", "memory as a selective derived view"],
 }
@@ -74,6 +84,9 @@ TAIL_BYTES = 24 * 1024                   # 24KB tail in pointer
 SUMMARY_MAX_CHARS = 240                  # bounded text suitable for later retrieval
 ARTIFACT_SOURCE_TYPE = "artifact"
 DEFAULT_ORPHAN_TTL_SECONDS = 24 * 60 * 60
+RETENTION_JOURNAL_SCHEMA_VERSION = 1
+RETENTION_JOURNAL_NAME = "retention-leases.jsonl"
+_ZERO_SHA256 = "0" * 64
 _SOURCE_COMPONENT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$")
 _ARTIFACT_DIGEST_PATTERN = re.compile(r"^(?:[0-9a-fA-F]{12}|[0-9a-fA-F]{64})$")
 _FULL_SHA256_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
@@ -92,6 +105,10 @@ class ArtifactRetentionError(ValueError):
     """A retention claim or cleanup plan violated an ownership contract."""
 
 
+class ArtifactLeaseJournalError(RuntimeError):
+    """A durable retention journal is corrupt or used out of phase."""
+
+
 class ArtifactCleanupStatus(str, Enum):
     """Terminal or planned state for one artifact cleanup decision."""
 
@@ -106,6 +123,15 @@ class ArtifactCleanupStatus(str, Enum):
     ALREADY_MISSING = "already_missing"
     RACE_DETECTED = "race_detected"
     DENIED = "denied"
+
+
+class ArtifactLeasePhase(str, Enum):
+    """Durable lifecycle for publishing and later releasing one reference."""
+
+    PREPARED = "prepared"
+    COMMITTED = "committed"
+    RELEASED = "released"
+    ABORTED = "aborted"
 
 
 @dataclass(frozen=True)
@@ -164,6 +190,85 @@ def _parse_aware_utc(value: str, *, field_name: str) -> datetime:
     if parsed.tzinfo is None:
         raise ArtifactRetentionError(f"{field_name} must include a timezone")
     return parsed.astimezone(timezone.utc)
+
+
+def _iso_utc(value: datetime | None = None) -> str:
+    return _aware_utc(value).isoformat()
+
+
+def _canonical_sha256(payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist a new journal entry on platforms with directory fsync."""
+
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _discard_incomplete_jsonl_tail(path: Path) -> None:
+    """Discard only a final record that never reached a newline boundary."""
+
+    if not path.exists() or path.stat().st_size == 0:
+        return
+    with path.open("rb+") as handle:
+        handle.seek(-1, os.SEEK_END)
+        if handle.read(1) == b"\n":
+            return
+        handle.seek(0)
+        content = handle.read()
+        last_newline = content.rfind(b"\n")
+        handle.seek(0)
+        handle.truncate(last_newline + 1)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+@contextmanager
+def _exclusive_journal_lock(path: Path) -> Iterator[None]:
+    """Serialize cooperating journal writers and cleanup readers."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f"{path.name}.lock")
+    if lock_path.is_symlink() or (lock_path.exists() and not lock_path.is_file()):
+        raise ArtifactLeaseJournalError("retention journal lock is not an owned file")
+    flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(lock_path, flags, 0o600)
+    locked = False
+    try:
+        if os.name == "nt":
+            if os.fstat(descriptor).st_size == 0:
+                os.write(descriptor, b"\0")
+                os.fsync(descriptor)
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+        locked = True
+        yield
+    finally:
+        if locked:
+            if os.name == "nt":
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+_PublicationValue = TypeVar("_PublicationValue")
 
 
 @dataclass(frozen=True)
@@ -286,6 +391,9 @@ class ArtifactRetentionClaim:
             field_name="retain_until",
         ) > _aware_utc(now)
 
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
 
 @dataclass(frozen=True)
 class ArtifactCleanupPolicy:
@@ -381,6 +489,681 @@ class ArtifactCleanupReport:
             "counts": self.counts,
             "decisions": [decision.to_dict() for decision in self.decisions],
         }
+
+
+@dataclass(frozen=True)
+class ArtifactLeaseTransaction:
+    """Immutable intent written before a Memory reference is published."""
+
+    transaction_id: str
+    session_id: str
+    claim: ArtifactRetentionClaim
+    prepared_at: str
+
+    def __post_init__(self) -> None:
+        _source_component(self.transaction_id, field_name="lease transaction ID")
+        session_id = _source_component(self.session_id, field_name="lease session")
+        parsed = parse_artifact_source_id(self.claim.source_id)
+        if parsed.session_id != session_id:
+            raise ArtifactRetentionError(
+                "lease transaction and retention claim sessions differ"
+            )
+        _parse_aware_utc(self.prepared_at, field_name="prepared_at")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "transaction_id": self.transaction_id,
+            "session_id": self.session_id,
+            "claim": self.claim.to_dict(),
+            "prepared_at": self.prepared_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> ArtifactLeaseTransaction:
+        claim_payload = payload.get("claim")
+        if not isinstance(claim_payload, dict):
+            raise ArtifactRetentionError("lease transaction has no retention claim")
+        return cls(
+            transaction_id=str(payload.get("transaction_id", "")),
+            session_id=str(payload.get("session_id", "")),
+            claim=ArtifactRetentionClaim(
+                source_id=str(claim_payload.get("source_id", "")),
+                content_sha256=str(claim_payload.get("content_sha256", "")),
+                reference_count=claim_payload.get("reference_count", 0),
+                retain_until=(
+                    None
+                    if claim_payload.get("retain_until") is None
+                    else str(claim_payload["retain_until"])
+                ),
+            ),
+            prepared_at=str(payload.get("prepared_at", "")),
+        )
+
+
+@dataclass(frozen=True)
+class ArtifactLeaseState:
+    """Recovered phase history for one reference publication transaction."""
+
+    transaction: ArtifactLeaseTransaction
+    phases: tuple[ArtifactLeasePhase, ...]
+
+    @property
+    def current_phase(self) -> ArtifactLeasePhase:
+        return self.phases[-1]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "transaction": self.transaction.to_dict(),
+            "phases": [phase.value for phase in self.phases],
+        }
+
+
+@dataclass(frozen=True)
+class ArtifactLeaseRecovery:
+    """Auditable, path-free claim view rebuilt from the durable journal."""
+
+    session_id: str
+    claims: tuple[ArtifactRetentionClaim, ...]
+    pending_transaction_ids: tuple[str, ...]
+    states: tuple[ArtifactLeaseState, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "claims": [claim.to_dict() for claim in self.claims],
+            "pending_transaction_ids": list(self.pending_transaction_ids),
+            "states": [state.to_dict() for state in self.states],
+        }
+
+
+class ArtifactRetentionJournal:
+    """Crash-recoverable owner for Artifact retention leases.
+
+    A PREPARED intent is durable before the caller publishes a Memory
+    reference. If the process exits after publication but before COMMITTED is
+    appended, recovery still treats PREPARED as an active, unbounded claim.
+    Cleanup and new journal events share one advisory lock so a reference
+    cannot be prepared between the final claim read and artifact deletion.
+    """
+
+    def __init__(self, session_dir: Path):
+        self.session_dir = Path(session_dir)
+        self.session_id = _source_component(
+            self.session_dir.name,
+            field_name="lease session",
+        )
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+        self.path = self.session_dir / RETENTION_JOURNAL_NAME
+
+    @staticmethod
+    def _intent_sha256(transaction: ArtifactLeaseTransaction) -> str:
+        return _canonical_sha256(transaction.to_dict())
+
+    @staticmethod
+    def _validate_transition(
+        current: ArtifactLeasePhase | None,
+        requested: ArtifactLeasePhase,
+    ) -> None:
+        allowed = {
+            None: {ArtifactLeasePhase.PREPARED},
+            ArtifactLeasePhase.PREPARED: {
+                ArtifactLeasePhase.COMMITTED,
+                ArtifactLeasePhase.ABORTED,
+            },
+            ArtifactLeasePhase.COMMITTED: {ArtifactLeasePhase.RELEASED},
+            ArtifactLeasePhase.RELEASED: set(),
+            ArtifactLeasePhase.ABORTED: set(),
+        }
+        if requested not in allowed[current]:
+            current_name = "none" if current is None else current.value
+            raise ArtifactLeaseJournalError(
+                f"invalid lease transition: {current_name} -> {requested.value}"
+            )
+
+    def _read_events_unlocked(self) -> list[dict[str, object]]:
+        if not self.path.exists():
+            return []
+        if self.path.is_symlink() or not self.path.is_file():
+            raise ArtifactLeaseJournalError(
+                "retention journal is not an owned regular file"
+            )
+        try:
+            encoded = self.path.read_bytes()
+            durable_end = encoded.rfind(b"\n") + 1
+            durable = encoded[:durable_end]
+            lines = durable.decode("utf-8").splitlines(keepends=True)
+        except UnicodeDecodeError as exc:
+            raise ArtifactLeaseJournalError(
+                "retention journal is not valid UTF-8"
+            ) from exc
+
+        events: list[dict[str, object]] = []
+        previous_hash = _ZERO_SHA256
+        for line_number, line in enumerate(lines, start=1):
+            if not line.strip():
+                raise ArtifactLeaseJournalError(
+                    f"blank retention journal record at line {line_number}"
+                )
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ArtifactLeaseJournalError(
+                    f"invalid retention journal JSON at line {line_number}"
+                ) from exc
+            if not isinstance(payload, dict):
+                raise ArtifactLeaseJournalError(
+                    f"retention journal line {line_number} is not an object"
+                )
+            if payload.get("schema_version") != RETENTION_JOURNAL_SCHEMA_VERSION:
+                raise ArtifactLeaseJournalError(
+                    f"unsupported retention journal schema at line {line_number}"
+                )
+            if payload.get("session_id") != self.session_id:
+                raise ArtifactLeaseJournalError(
+                    f"retention journal line {line_number} belongs to another session"
+                )
+            sequence = payload.get("sequence")
+            if (
+                isinstance(sequence, bool)
+                or not isinstance(sequence, int)
+                or sequence != line_number
+            ):
+                raise ArtifactLeaseJournalError(
+                    f"retention journal expected sequence {line_number}"
+                )
+            if payload.get("previous_sha256") != previous_hash:
+                raise ArtifactLeaseJournalError(
+                    f"retention journal hash chain broke at line {line_number}"
+                )
+            event_hash = payload.get("event_sha256")
+            if not isinstance(event_hash, str) or not _FULL_SHA256_PATTERN.fullmatch(
+                event_hash
+            ):
+                raise ArtifactLeaseJournalError(
+                    f"invalid retention event hash at line {line_number}"
+                )
+            unsigned = dict(payload)
+            unsigned.pop("event_sha256")
+            if _canonical_sha256(unsigned) != event_hash:
+                raise ArtifactLeaseJournalError(
+                    f"retention event hash mismatch at line {line_number}"
+                )
+            try:
+                ArtifactLeasePhase(payload.get("phase"))
+                _source_component(
+                    str(payload.get("transaction_id", "")),
+                    field_name="lease transaction ID",
+                )
+                _parse_aware_utc(
+                    str(payload.get("recorded_at", "")),
+                    field_name="recorded_at",
+                )
+            except (ArtifactRetentionError, TypeError, ValueError) as exc:
+                raise ArtifactLeaseJournalError(
+                    f"invalid retention journal fields at line {line_number}"
+                ) from exc
+            intent_hash = payload.get("intent_sha256")
+            if not isinstance(intent_hash, str) or not _FULL_SHA256_PATTERN.fullmatch(
+                intent_hash
+            ):
+                raise ArtifactLeaseJournalError(
+                    f"invalid retention intent hash at line {line_number}"
+                )
+            events.append(payload)
+            previous_hash = event_hash
+        return events
+
+    def _fold_events(
+        self,
+        events: Sequence[dict[str, object]],
+    ) -> tuple[ArtifactLeaseState, ...]:
+        states: dict[str, ArtifactLeaseState] = {}
+        for line_number, payload in enumerate(events, start=1):
+            phase = ArtifactLeasePhase(payload["phase"])
+            transaction_id = str(payload["transaction_id"])
+            intent_hash = str(payload["intent_sha256"])
+            state = states.get(transaction_id)
+            current = None if state is None else state.current_phase
+            self._validate_transition(current, phase)
+            if phase is ArtifactLeasePhase.PREPARED:
+                intent = payload.get("intent")
+                if not isinstance(intent, dict):
+                    raise ArtifactLeaseJournalError(
+                        f"prepared lease at line {line_number} has no intent"
+                    )
+                try:
+                    transaction = ArtifactLeaseTransaction.from_dict(intent)
+                except (ArtifactRetentionError, TypeError, ValueError) as exc:
+                    raise ArtifactLeaseJournalError(
+                        f"invalid lease intent at line {line_number}"
+                    ) from exc
+                if transaction.transaction_id != transaction_id:
+                    raise ArtifactLeaseJournalError(
+                        "lease transaction ID differs from prepared intent"
+                    )
+                if transaction.session_id != self.session_id:
+                    raise ArtifactLeaseJournalError(
+                        "prepared lease belongs to another session"
+                    )
+                if transaction.prepared_at != payload["recorded_at"]:
+                    raise ArtifactLeaseJournalError(
+                        "prepared lease timestamp differs from intent"
+                    )
+                if self._intent_sha256(transaction) != intent_hash:
+                    raise ArtifactLeaseJournalError(
+                        "prepared lease intent hash mismatch"
+                    )
+                states[transaction_id] = ArtifactLeaseState(
+                    transaction=transaction,
+                    phases=(phase,),
+                )
+                continue
+
+            if state is None:
+                raise ArtifactLeaseJournalError(
+                    f"lease transaction {transaction_id} has no prepared intent"
+                )
+            if self._intent_sha256(state.transaction) != intent_hash:
+                raise ArtifactLeaseJournalError(
+                    f"lease transaction {transaction_id} changed intent"
+                )
+            if "intent" in payload:
+                raise ArtifactLeaseJournalError(
+                    f"lease phase {phase.value} unexpectedly repeats its intent"
+                )
+            states[transaction_id] = ArtifactLeaseState(
+                transaction=state.transaction,
+                phases=(*state.phases, phase),
+            )
+        return tuple(states.values())
+
+    def _read_states_unlocked(
+        self,
+    ) -> tuple[list[dict[str, object]], tuple[ArtifactLeaseState, ...]]:
+        events = self._read_events_unlocked()
+        return events, self._fold_events(events)
+
+    def _append_event_unlocked(
+        self,
+        events: Sequence[dict[str, object]],
+        transaction: ArtifactLeaseTransaction,
+        phase: ArtifactLeasePhase,
+        *,
+        recorded_at: datetime | None = None,
+    ) -> None:
+        timestamp = (
+            transaction.prepared_at
+            if phase is ArtifactLeasePhase.PREPARED
+            else _iso_utc(recorded_at)
+        )
+        previous_hash = (
+            str(events[-1]["event_sha256"]) if events else _ZERO_SHA256
+        )
+        payload: dict[str, object] = {
+            "schema_version": RETENTION_JOURNAL_SCHEMA_VERSION,
+            "sequence": len(events) + 1,
+            "session_id": self.session_id,
+            "transaction_id": transaction.transaction_id,
+            "phase": phase.value,
+            "recorded_at": timestamp,
+            "intent_sha256": self._intent_sha256(transaction),
+            "previous_sha256": previous_hash,
+        }
+        if phase is ArtifactLeasePhase.PREPARED:
+            payload["intent"] = transaction.to_dict()
+        payload["event_sha256"] = _canonical_sha256(payload)
+        encoded = (
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+            + "\n"
+        ).encode("utf-8")
+        if self.path.is_symlink() or (self.path.exists() and not self.path.is_file()):
+            raise ArtifactLeaseJournalError(
+                "retention journal is not an owned regular file"
+            )
+        _discard_incomplete_jsonl_tail(self.path)
+        flags = (
+            os.O_APPEND
+            | os.O_CREAT
+            | os.O_WRONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        descriptor = os.open(
+            self.path,
+            flags,
+            0o600,
+        )
+        try:
+            written = os.write(descriptor, encoded)
+            if written != len(encoded):
+                raise OSError(
+                    f"short retention journal write: {written}/{len(encoded)} bytes"
+                )
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        _fsync_directory(self.path.parent)
+
+    def _validate_claim_artifact_unlocked(
+        self,
+        claim: ArtifactRetentionClaim,
+    ) -> None:
+        """Prove the leased bytes still exist while cleanup is excluded."""
+
+        parsed = parse_artifact_source_id(claim.source_id)
+        if parsed.session_id != self.session_id:
+            raise ArtifactRetentionError(
+                "retention claim belongs to a different artifact session"
+            )
+        owned_root = (self.session_dir / "tool-results").resolve()
+        candidate = owned_root / parsed.filename
+        try:
+            if candidate.is_symlink():
+                raise ArtifactRetentionError(
+                    "cannot lease a symbolic-link artifact"
+                )
+            owned_path = candidate.resolve(strict=True)
+            if owned_path.parent != owned_root or not owned_path.is_file():
+                raise ArtifactRetentionError(
+                    "cannot lease an artifact outside the owned tool-results root"
+                )
+            before_hash = owned_path.stat()
+            digest = hashlib.sha256()
+            with owned_path.open("rb") as handle:
+                while chunk := handle.read(64 * 1024):
+                    digest.update(chunk)
+            after_hash = owned_path.stat()
+        except FileNotFoundError as exc:
+            raise ArtifactRetentionError(
+                f"cannot lease missing artifact {parsed.filename}"
+            ) from exc
+        if (
+            before_hash.st_size != after_hash.st_size
+            or before_hash.st_mtime_ns != after_hash.st_mtime_ns
+            or before_hash.st_dev != after_hash.st_dev
+            or before_hash.st_ino != after_hash.st_ino
+            or digest.hexdigest() != claim.content_sha256
+        ):
+            raise ArtifactRetentionError(
+                f"cannot lease changed artifact {parsed.filename}"
+            )
+
+    def _checkpoint(self, name: str) -> None:
+        """Fault-injection seam used to prove post-fsync crash recovery."""
+
+    def _prepare(
+        self,
+        claim: ArtifactRetentionClaim,
+        *,
+        transaction_id: str | None = None,
+        prepared_at: datetime | None = None,
+    ) -> tuple[ArtifactLeaseTransaction, bool]:
+        transaction = ArtifactLeaseTransaction(
+            transaction_id=transaction_id or uuid.uuid4().hex,
+            session_id=self.session_id,
+            claim=claim,
+            prepared_at=_iso_utc(prepared_at),
+        )
+        with _exclusive_journal_lock(self.path):
+            events, states = self._read_states_unlocked()
+            existing = next(
+                (
+                    state
+                    for state in states
+                    if state.transaction.transaction_id == transaction.transaction_id
+                ),
+                None,
+            )
+            if existing is not None:
+                if (
+                    existing.transaction.session_id != transaction.session_id
+                    or existing.transaction.claim != transaction.claim
+                ):
+                    raise ArtifactLeaseJournalError(
+                        f"lease transaction {transaction.transaction_id} changed intent"
+                    )
+                return existing.transaction, False
+            self._validate_claim_artifact_unlocked(transaction.claim)
+            self._append_event_unlocked(
+                events,
+                transaction,
+                ArtifactLeasePhase.PREPARED,
+            )
+            self._checkpoint("after_prepared")
+        return transaction, True
+
+    def prepare(
+        self,
+        claim: ArtifactRetentionClaim,
+        *,
+        transaction_id: str | None = None,
+        prepared_at: datetime | None = None,
+    ) -> ArtifactLeaseTransaction:
+        """Durably prepare a protective lease before publishing a reference."""
+
+        transaction, _ = self._prepare(
+            claim,
+            transaction_id=transaction_id,
+            prepared_at=prepared_at,
+        )
+        return transaction
+
+    def _transition(
+        self,
+        transaction_id: str,
+        phase: ArtifactLeasePhase,
+        *,
+        recorded_at: datetime | None = None,
+    ) -> ArtifactLeaseState:
+        normalized_id = _source_component(
+            transaction_id,
+            field_name="lease transaction ID",
+        )
+        with _exclusive_journal_lock(self.path):
+            events, states = self._read_states_unlocked()
+            state = next(
+                (
+                    item
+                    for item in states
+                    if item.transaction.transaction_id == normalized_id
+                ),
+                None,
+            )
+            if state is None:
+                raise ArtifactLeaseJournalError(
+                    f"unknown lease transaction: {normalized_id}"
+                )
+            if state.current_phase is phase:
+                return state
+            self._validate_transition(state.current_phase, phase)
+            self._append_event_unlocked(
+                events,
+                state.transaction,
+                phase,
+                recorded_at=recorded_at,
+            )
+            updated = ArtifactLeaseState(
+                transaction=state.transaction,
+                phases=(*state.phases, phase),
+            )
+            self._checkpoint(f"after_{phase.value}")
+            return updated
+
+    def commit(
+        self,
+        transaction_id: str,
+        *,
+        committed_at: datetime | None = None,
+    ) -> ArtifactLeaseState:
+        return self._transition(
+            transaction_id,
+            ArtifactLeasePhase.COMMITTED,
+            recorded_at=committed_at,
+        )
+
+    def release(
+        self,
+        transaction_id: str,
+        *,
+        released_at: datetime | None = None,
+    ) -> ArtifactLeaseState:
+        return self._transition(
+            transaction_id,
+            ArtifactLeasePhase.RELEASED,
+            recorded_at=released_at,
+        )
+
+    def abort(
+        self,
+        transaction_id: str,
+        *,
+        aborted_at: datetime | None = None,
+    ) -> ArtifactLeaseState:
+        return self._transition(
+            transaction_id,
+            ArtifactLeasePhase.ABORTED,
+            recorded_at=aborted_at,
+        )
+
+    def publish_reference(
+        self,
+        claim: ArtifactRetentionClaim,
+        publisher: Callable[[], _PublicationValue],
+        *,
+        transaction_id: str | None = None,
+        prepared_at: datetime | None = None,
+        committed_at: datetime | None = None,
+    ) -> tuple[ArtifactLeaseTransaction, _PublicationValue]:
+        """Prepare, invoke a Memory publisher, then commit its durable lease."""
+
+        transaction, created = self._prepare(
+            claim,
+            transaction_id=transaction_id,
+            prepared_at=prepared_at,
+        )
+        if not created:
+            raise ArtifactLeaseJournalError(
+                "lease publication retry requires explicit Memory reconciliation"
+            )
+        try:
+            value = publisher()
+        except Exception:
+            self.abort(transaction.transaction_id)
+            raise
+        self.commit(transaction.transaction_id, committed_at=committed_at)
+        return transaction, value
+
+    def remove_reference(
+        self,
+        transaction_id: str,
+        remover: Callable[[], _PublicationValue],
+        *,
+        released_at: datetime | None = None,
+    ) -> _PublicationValue:
+        """Remove the Memory reference before releasing its protective lease."""
+
+        normalized_id = _source_component(
+            transaction_id,
+            field_name="lease transaction ID",
+        )
+        with _exclusive_journal_lock(self.path):
+            events, states = self._read_states_unlocked()
+            state = next(
+                (
+                    item
+                    for item in states
+                    if item.transaction.transaction_id == normalized_id
+                ),
+                None,
+            )
+            if state is None:
+                raise ArtifactLeaseJournalError(
+                    f"unknown lease transaction: {normalized_id}"
+                )
+            self._validate_transition(
+                state.current_phase,
+                ArtifactLeasePhase.RELEASED,
+            )
+            value = remover()
+            self._append_event_unlocked(
+                events,
+                state.transaction,
+                ArtifactLeasePhase.RELEASED,
+                recorded_at=released_at,
+            )
+            self._checkpoint("after_released")
+            return value
+
+    def _recover_unlocked(self, *, now: datetime) -> ArtifactLeaseRecovery:
+        _, states = self._read_states_unlocked()
+        protected: dict[str, list[ArtifactRetentionClaim]] = {}
+        pending: list[str] = []
+        for state in states:
+            claim = state.transaction.claim
+            if state.current_phase is ArtifactLeasePhase.PREPARED:
+                pending.append(state.transaction.transaction_id)
+                claim = replace(claim, retain_until=None)
+            elif state.current_phase is ArtifactLeasePhase.COMMITTED:
+                if not claim.is_active(now):
+                    continue
+            else:
+                continue
+            parsed = parse_artifact_source_id(claim.source_id)
+            protected.setdefault(parsed.filename, []).append(claim)
+
+        claims: list[ArtifactRetentionClaim] = []
+        for filename, grouped in sorted(protected.items()):
+            digests = {claim.content_sha256 for claim in grouped}
+            if len(digests) != 1:
+                raise ArtifactLeaseJournalError(
+                    f"active leases disagree on digest for {filename}"
+                )
+            retain_until: str | None
+            if any(claim.retain_until is None for claim in grouped):
+                retain_until = None
+            else:
+                deadlines = [
+                    _parse_aware_utc(
+                        str(claim.retain_until),
+                        field_name="retain_until",
+                    )
+                    for claim in grouped
+                ]
+                retain_until = max(deadlines).isoformat()
+            claims.append(ArtifactRetentionClaim(
+                source_id=grouped[0].source_id,
+                content_sha256=grouped[0].content_sha256,
+                reference_count=sum(claim.reference_count for claim in grouped),
+                retain_until=retain_until,
+            ))
+        return ArtifactLeaseRecovery(
+            session_id=self.session_id,
+            claims=tuple(claims),
+            pending_transaction_ids=tuple(sorted(pending)),
+            states=states,
+        )
+
+    @contextmanager
+    def locked_recovery(
+        self,
+        *,
+        now: datetime | None = None,
+    ) -> Iterator[ArtifactLeaseRecovery]:
+        """Hold the journal boundary while a caller plans or applies cleanup."""
+
+        observed_at = _aware_utc(now)
+        with _exclusive_journal_lock(self.path):
+            yield self._recover_unlocked(now=observed_at)
+
+    def recover(self, *, now: datetime | None = None) -> ArtifactLeaseRecovery:
+        with self.locked_recovery(now=now) as recovery:
+            return recovery
+
+    def current_claims(
+        self,
+        *,
+        now: datetime | None = None,
+    ) -> tuple[ArtifactRetentionClaim, ...]:
+        return self.recover(now=now).claims
 
 
 # ======================================================================
@@ -694,6 +1477,30 @@ class ToolResultExternalizer:
     ) -> ArtifactCleanupPlan:
         """Plan cleanup without deleting data or trusting Memory-owned paths."""
 
+        return self._plan_cleanup(
+            claims,
+            policy=policy,
+            now=now,
+            journal_verified=False,
+        )
+
+    def _plan_cleanup(
+        self,
+        claims: Sequence[ArtifactRetentionClaim],
+        *,
+        policy: ArtifactCleanupPolicy | None,
+        now: datetime | None,
+        journal_verified: bool,
+    ) -> ArtifactCleanupPlan:
+
+        journal_path = self.session_dir / RETENTION_JOURNAL_NAME
+        if (
+            (journal_path.exists() or journal_path.is_symlink())
+            and not journal_verified
+        ):
+            raise ArtifactRetentionError(
+                "durable retention journal exists; use journal-aware cleanup"
+            )
         observed_at = _aware_utc(now)
         active_policy = policy or ArtifactCleanupPolicy()
         all_claims, active_claims = self._validated_claims(
@@ -860,6 +1667,30 @@ class ToolResultExternalizer:
     ) -> ArtifactCleanupReport:
         """Apply deletions after rechecking current claims and file identity."""
 
+        return self._apply_cleanup(
+            plan,
+            claims=claims,
+            now=now,
+            journal_verified=False,
+        )
+
+    def _apply_cleanup(
+        self,
+        plan: ArtifactCleanupPlan,
+        *,
+        claims: Sequence[ArtifactRetentionClaim] | None,
+        now: datetime | None,
+        journal_verified: bool,
+    ) -> ArtifactCleanupReport:
+
+        journal_path = self.session_dir / RETENTION_JOURNAL_NAME
+        if (
+            (journal_path.exists() or journal_path.is_symlink())
+            and not journal_verified
+        ):
+            raise ArtifactRetentionError(
+                "durable retention journal exists; use journal-aware cleanup"
+            )
         if not isinstance(plan, ArtifactCleanupPlan):
             raise ArtifactRetentionError("cleanup requires an ArtifactCleanupPlan")
         if plan.session_id != self.session_dir.name:
@@ -973,6 +1804,80 @@ class ToolResultExternalizer:
 
         plan = self.plan_cleanup(claims, policy=policy, now=now)
         return self.apply_cleanup(plan, claims=claims, now=now)
+
+    def _validated_journal(
+        self,
+        journal: ArtifactRetentionJournal,
+    ) -> ArtifactRetentionJournal:
+        if not isinstance(journal, ArtifactRetentionJournal):
+            raise ArtifactRetentionError(
+                "artifact cleanup requires an ArtifactRetentionJournal"
+            )
+        if journal.session_dir.resolve() != self.session_dir.resolve():
+            raise ArtifactRetentionError(
+                "retention journal belongs to a different artifact session"
+            )
+        return journal
+
+    def plan_cleanup_from_journal(
+        self,
+        journal: ArtifactRetentionJournal,
+        *,
+        policy: ArtifactCleanupPolicy | None = None,
+        now: datetime | None = None,
+    ) -> ArtifactCleanupPlan:
+        """Plan against a recovered journal view without accepting raw claims."""
+
+        owner = self._validated_journal(journal)
+        recovery = owner.recover(now=now)
+        return self._plan_cleanup(
+            recovery.claims,
+            policy=policy,
+            now=now,
+            journal_verified=True,
+        )
+
+    def apply_cleanup_from_journal(
+        self,
+        plan: ArtifactCleanupPlan,
+        journal: ArtifactRetentionJournal,
+        *,
+        now: datetime | None = None,
+    ) -> ArtifactCleanupReport:
+        """Re-fold and lock the journal across final validation and deletion."""
+
+        owner = self._validated_journal(journal)
+        with owner.locked_recovery(now=now) as recovery:
+            return self._apply_cleanup(
+                plan,
+                claims=recovery.claims,
+                now=now,
+                journal_verified=True,
+            )
+
+    def cleanup_artifacts_from_journal(
+        self,
+        journal: ArtifactRetentionJournal,
+        *,
+        policy: ArtifactCleanupPolicy | None = None,
+        now: datetime | None = None,
+    ) -> ArtifactCleanupReport:
+        """Plan and apply one cleanup pass under the journal consistency lock."""
+
+        owner = self._validated_journal(journal)
+        with owner.locked_recovery(now=now) as recovery:
+            plan = self._plan_cleanup(
+                recovery.claims,
+                policy=policy,
+                now=now,
+                journal_verified=True,
+            )
+            return self._apply_cleanup(
+                plan,
+                claims=recovery.claims,
+                now=now,
+                journal_verified=True,
+            )
 
     def externalize(
         self,

--- a/s13_output_externalization/images/output-externalization.svg
+++ b/s13_output_externalization/images/output-externalization.svg
@@ -24,7 +24,7 @@
 
   <!-- Title -->
   <text x="400" y="38" text-anchor="middle" font-size="24" font-weight="700" fill="#202124">工具输出外部化 (Output Swap)</text>
-  <text x="400" y="60" text-anchor="middle" font-size="13" fill="#5f6368">完整正文归 Artifact；Context / Memory 留有界引用；GC 按租约与 digest 回收孤儿</text>
+  <text x="400" y="60" text-anchor="middle" font-size="13" fill="#5f6368">正文归 Artifact；引用先写 lease journal；重启恢复后再按 digest 回收孤儿</text>
 
   <!-- ===== LEFT: 上下文窗口 (RAM) ===== -->
   <rect x="40" y="110" width="280" height="200" rx="12" fill="url(#ram-grad)" stroke="#1a73e8" stroke-width="2"/>
@@ -116,16 +116,16 @@
 
   <!-- ===== Reference-aware lifecycle ===== -->
   <rect x="40" y="555" width="720" height="88" rx="12" fill="#ffffff" stroke="#f9ab00" stroke-width="1.5"/>
-  <text x="60" y="577" font-size="13" font-weight="700" fill="#a15c00">引用感知 GC（session close / scheduled cleanup）</text>
+  <text x="60" y="577" font-size="13" font-weight="700" fill="#a15c00">Crash-safe 引用生命周期与 GC</text>
   <rect x="60" y="588" width="190" height="38" rx="7" fill="#fff7e0" stroke="#f9ab00"/>
-  <text x="155" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#a15c00">RetentionClaim</text>
-  <text x="155" y="618" text-anchor="middle" font-size="9" fill="#5f6368">source ID + digest + lease</text>
+  <text x="155" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#a15c00">Lease journal</text>
+  <text x="155" y="618" text-anchor="middle" font-size="9" fill="#5f6368">prepare → commit → release</text>
   <line x1="250" y1="607" x2="292" y2="607" stroke="#f9ab00" stroke-width="2" marker-end="url(#arrow-green)"/>
   <rect x="300" y="588" width="200" height="38" rx="7" fill="#e8f0fe" stroke="#1a73e8"/>
-  <text x="400" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#174ea6">plan → snapshot → recheck</text>
-  <text x="400" y="618" text-anchor="middle" font-size="9" fill="#5f6368">identity + mtime + size + SHA-256</text>
+  <text x="400" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#174ea6">locked restart recovery</text>
+  <text x="400" y="618" text-anchor="middle" font-size="9" fill="#5f6368">pending prepare 默认 retain</text>
   <line x1="500" y1="607" x2="542" y2="607" stroke="#1a73e8" stroke-width="2" marker-end="url(#arrow-blue)"/>
   <rect x="550" y="588" width="190" height="38" rx="7" fill="#e6f4ea" stroke="#34a853"/>
-  <text x="645" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#137333">retain / delete orphan</text>
-  <text x="645" y="618" text-anchor="middle" font-size="9" fill="#5f6368">异常或竞态一律 fail-closed</text>
+  <text x="645" y="604" text-anchor="middle" font-size="11" font-weight="700" fill="#137333">snapshot → recheck → GC</text>
+  <text x="645" y="618" text-anchor="middle" font-size="9" fill="#5f6368">hash / identity 异常 fail-closed</text>
 </svg>

--- a/tests/test_layered_memory_walkthrough.py
+++ b/tests/test_layered_memory_walkthrough.py
@@ -46,6 +46,7 @@ def test_layered_memory_walkthrough_is_keyless_and_restart_safe(
     assert result.returncode == 0, result.stdout[-4_000:]
     assert "RESULT: OK" in result.stdout
     assert "created -> unchanged; bob empty=True" in result.stdout
+    assert "lease recovered=1" in result.stdout
     assert "referenced retained=1; expired orphan deleted=1" in result.stdout
     assert "durable preserved=True" in result.stdout
     assert "sources verified=2" in result.stdout
@@ -75,6 +76,11 @@ def test_layered_memory_walkthrough_is_keyless_and_restart_safe(
     assert "content" not in artifact_reference
     assert len(artifact_reference["content_sha256"]) == 64
     assert Path(artifact_reference["artifact_path"]).stat().st_size > 30_000
+    lease_recovery = artifact_layer["lease_recovery"]
+    assert lease_recovery["pending_transaction_ids"] == []
+    assert lease_recovery["claims"][0]["reference_count"] == 1
+    assert lease_recovery["states"][0]["phases"] == ["prepared", "committed"]
+    assert str(home) not in json.dumps(lease_recovery, sort_keys=True)
     assert artifact_layer["cleanup"]["counts"] == {
         "deleted": 1,
         "retained_referenced": 1,

--- a/tests/test_output_externalization.py
+++ b/tests/test_output_externalization.py
@@ -7,8 +7,10 @@ import importlib.util
 import json
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from threading import Barrier
 
 import pytest
 
@@ -385,3 +387,444 @@ def test_cleanup_rejects_cross_session_claims_and_symlink_escape(
     assert plan.decisions[0].status is s13.ArtifactCleanupStatus.DENIED
     externalizer.apply_cleanup(plan)
     assert outside.read_text(encoding="utf-8") == "outside owner"
+
+
+def test_retention_journal_survives_restart_and_drives_cleanup(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "journal-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    referenced = externalizer.externalize(
+        "durable referenced evidence",
+        "search",
+        summary="Referenced evidence persisted before cleanup.",
+    ).artifact
+    orphan = externalizer.externalize(
+        "old orphan",
+        "search",
+        summary="Unreferenced diagnostic output.",
+    ).artifact
+    for artifact in (referenced, orphan):
+        _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(referenced.for_memory())
+    published: list[str] = []
+    transaction, result = journal.publish_reference(
+        claim,
+        lambda: published.append(referenced.source.source_id) or "published",
+        transaction_id="publish-reference-1",
+        prepared_at=now - timedelta(minutes=2),
+        committed_at=now - timedelta(minutes=1),
+    )
+
+    assert result == "published"
+    assert published == [referenced.source.source_id]
+    assert transaction.transaction_id == "publish-reference-1"
+    restarted_journal = s13.ArtifactRetentionJournal(session_dir)
+    recovery = restarted_journal.recover(now=now)
+    assert len(recovery.claims) == 1
+    assert recovery.claims[0] == claim
+    assert recovery.pending_transaction_ids == ()
+    assert recovery.states[0].phases == (
+        s13.ArtifactLeasePhase.PREPARED,
+        s13.ArtifactLeasePhase.COMMITTED,
+    )
+    assert str(tmp_path) not in json.dumps(recovery.to_dict(), sort_keys=True)
+    retried_publisher_called = False
+
+    def retried_publisher() -> None:
+        nonlocal retried_publisher_called
+        retried_publisher_called = True
+
+    with pytest.raises(s13.ArtifactLeaseJournalError, match="reconciliation"):
+        restarted_journal.publish_reference(
+            claim,
+            retried_publisher,
+            transaction_id=transaction.transaction_id,
+            prepared_at=now,
+        )
+    assert retried_publisher_called is False
+
+    restarted_externalizer = s13.ToolResultExternalizer(session_dir)
+    with pytest.raises(s13.ArtifactRetentionError, match="journal-aware cleanup"):
+        restarted_externalizer.cleanup_artifacts((claim,), now=now)
+    report = restarted_externalizer.cleanup_artifacts_from_journal(
+        restarted_journal,
+        policy=s13.ArtifactCleanupPolicy(
+            orphan_ttl_seconds=60,
+            dry_run=False,
+        ),
+        now=now,
+    )
+    assert report.counts == {"retained_referenced": 1, "deleted": 1}
+    assert referenced.path.exists()
+    assert not orphan.path.exists()
+
+
+def test_prepared_lease_protects_reference_when_commit_was_not_written(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "prepared-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "memory publication completed before process exit",
+        "search",
+        summary="Reference publication crossed the crash boundary.",
+    ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    expired_claim = s13.ArtifactRetentionClaim.from_memory_reference(
+        artifact.for_memory(),
+        retain_until=(now - timedelta(hours=1)).isoformat(),
+    )
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    journal.prepare(
+        expired_claim,
+        transaction_id="crash-before-commit",
+        prepared_at=now - timedelta(hours=2),
+    )
+
+    # The external Memory write succeeded, but the process exited before the
+    # committed phase. A fresh journal must keep the uncertain intent alive.
+    memory_publication = tmp_path / "published-reference.json"
+    memory_publication.write_text(
+        json.dumps(artifact.for_memory().to_dict(), sort_keys=True),
+        encoding="utf-8",
+    )
+    restarted = s13.ArtifactRetentionJournal(session_dir)
+    recovery = restarted.recover(now=now)
+    assert recovery.pending_transaction_ids == ("crash-before-commit",)
+    assert recovery.claims[0].retain_until is None
+
+    report = externalizer.cleanup_artifacts_from_journal(
+        restarted,
+        policy=s13.ArtifactCleanupPolicy(
+            orphan_ttl_seconds=60,
+            dry_run=False,
+        ),
+        now=now,
+    )
+    assert report.counts == {"retained_referenced": 1}
+    assert artifact.path.exists()
+
+
+def test_expired_committed_lease_allows_orphan_collection(s13, tmp_path: Path) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "expired-journal-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "expired committed evidence",
+        "search",
+        summary="The committed lease has reached its explicit deadline.",
+    ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(
+        artifact.for_memory(),
+        retain_until=(now - timedelta(seconds=1)).isoformat(),
+    )
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    journal.prepare(
+        claim,
+        transaction_id="expired-committed-reference",
+        prepared_at=now - timedelta(hours=2),
+    )
+    journal.commit(
+        "expired-committed-reference",
+        committed_at=now - timedelta(hours=1),
+    )
+
+    assert journal.recover(now=now).claims == ()
+    report = externalizer.cleanup_artifacts_from_journal(
+        journal,
+        policy=s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False),
+        now=now,
+    )
+    assert report.counts == {"deleted": 1}
+    assert not artifact.path.exists()
+
+
+def test_failed_reference_publication_aborts_lease(s13, tmp_path: Path) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "aborted-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "publication failure evidence",
+        "search",
+        summary="Reference publisher raises before commit.",
+    ).artifact
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    journal = s13.ArtifactRetentionJournal(session_dir)
+
+    def reject_publication() -> None:
+        raise RuntimeError("memory adapter rejected the write")
+
+    with pytest.raises(RuntimeError, match="rejected the write"):
+        journal.publish_reference(
+            claim,
+            reject_publication,
+            transaction_id="aborted-publication",
+            prepared_at=now,
+        )
+
+    recovery = s13.ArtifactRetentionJournal(session_dir).recover(now=now)
+    assert recovery.claims == ()
+    assert recovery.states[0].current_phase is s13.ArtifactLeasePhase.ABORTED
+
+
+def test_post_fsync_commit_crash_recovers_and_retry_is_idempotent(
+    s13, tmp_path: Path, monkeypatch
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "commit-crash-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "commit crash evidence",
+        "search",
+        summary="Committed phase reaches disk before process exit.",
+    ).artifact
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    transaction = journal.prepare(
+        claim,
+        transaction_id="commit-crash",
+        prepared_at=now - timedelta(minutes=1),
+    )
+
+    def crash_after_fsync(name: str) -> None:
+        if name == "after_committed":
+            raise RuntimeError("simulated process exit after commit fsync")
+
+    monkeypatch.setattr(journal, "_checkpoint", crash_after_fsync)
+    with pytest.raises(RuntimeError, match="after commit fsync"):
+        journal.commit(transaction.transaction_id, committed_at=now)
+
+    restarted = s13.ArtifactRetentionJournal(session_dir)
+    recovery = restarted.recover(now=now)
+    assert recovery.states[0].current_phase is s13.ArtifactLeasePhase.COMMITTED
+    journal_before = restarted.path.read_bytes()
+    restarted.commit(transaction.transaction_id, committed_at=now)
+    assert restarted.path.read_bytes() == journal_before
+
+
+def test_journal_discards_only_partial_tail_and_detects_tampering(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "journal-integrity-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "journal integrity evidence",
+        "search",
+        summary="Journal integrity test artifact.",
+    ).artifact
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    transaction = journal.prepare(
+        claim,
+        transaction_id="integrity-transaction",
+        prepared_at=now - timedelta(minutes=2),
+    )
+    journal.commit(transaction.transaction_id, committed_at=now - timedelta(minutes=1))
+    with journal.path.open("ab") as handle:
+        handle.write(b'{"partial_crash_record":"\xe2\x82')
+
+    assert len(s13.ArtifactRetentionJournal(session_dir).recover(now=now).claims) == 1
+    restarted = s13.ArtifactRetentionJournal(session_dir)
+    restarted.release(transaction.transaction_id, released_at=now)
+    records = [
+        json.loads(line)
+        for line in restarted.path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["sequence"] for record in records] == [1, 2, 3]
+
+    valid_journal = restarted.path.read_text(encoding="utf-8")
+    restarted.path.write_text(valid_journal + "{complete bad record}\n", encoding="utf-8")
+    with pytest.raises(s13.ArtifactLeaseJournalError, match="invalid.*JSON"):
+        s13.ArtifactRetentionJournal(session_dir).recover(now=now)
+    restarted.path.write_text(valid_journal, encoding="utf-8")
+
+    records[0]["intent"]["claim"]["reference_count"] = 99
+    restarted.path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(s13.ArtifactLeaseJournalError, match="hash mismatch"):
+        s13.ArtifactRetentionJournal(session_dir).recover(now=now)
+
+
+def test_journal_aggregates_and_releases_multiple_references(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "aggregate-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "shared evidence",
+        "search",
+        summary="Two Memory records reference one Artifact.",
+    ).artifact
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    for transaction_id in ("reference-a", "reference-b"):
+        journal.prepare(claim, transaction_id=transaction_id, prepared_at=now)
+        journal.commit(transaction_id, committed_at=now)
+
+    assert journal.recover(now=now).claims[0].reference_count == 2
+
+    def fail_removal() -> None:
+        raise RuntimeError("reference removal failed")
+
+    with pytest.raises(RuntimeError, match="reference removal failed"):
+        journal.remove_reference(
+            "reference-a",
+            fail_removal,
+            released_at=now,
+        )
+    assert journal.recover(now=now).claims[0].reference_count == 2
+    assert journal.remove_reference(
+        "reference-a",
+        lambda: "removed",
+        released_at=now,
+    ) == "removed"
+    assert journal.recover(now=now).claims[0].reference_count == 1
+    journal.release("reference-b", released_at=now)
+    assert journal.recover(now=now).claims == ()
+
+
+def test_concurrent_journal_writers_preserve_sequence_and_hash_chain(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "concurrent-journal-session"
+    artifact = s13.ToolResultExternalizer(session_dir).externalize(
+        "shared concurrent evidence",
+        "search",
+        summary="Concurrent publishers share one immutable Artifact.",
+    ).artifact
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    writer_count = 6
+    barrier = Barrier(writer_count)
+
+    def prepare(index: int) -> None:
+        writer = s13.ArtifactRetentionJournal(session_dir)
+        barrier.wait()
+        writer.prepare(
+            claim,
+            transaction_id=f"concurrent-reference-{index}",
+            prepared_at=now,
+        )
+
+    with ThreadPoolExecutor(max_workers=writer_count) as executor:
+        list(executor.map(prepare, range(writer_count)))
+
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    recovery = journal.recover(now=now)
+    assert recovery.claims[0].reference_count == writer_count
+    assert len(recovery.pending_transaction_ids) == writer_count
+    records = [
+        json.loads(line)
+        for line in journal.path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["sequence"] for record in records] == list(
+        range(1, writer_count + 1)
+    )
+
+
+def test_journal_apply_rechecks_reference_added_after_plan(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "journal-late-claim-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "late durable reference",
+        "search",
+        summary="Reference is published after cleanup planning.",
+    ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    policy = s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False)
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    plan = externalizer.plan_cleanup_from_journal(journal, policy=policy, now=now)
+
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    journal.publish_reference(
+        claim,
+        lambda: None,
+        transaction_id="late-reference",
+        prepared_at=now,
+        committed_at=now,
+    )
+    report = externalizer.apply_cleanup_from_journal(plan, journal, now=now)
+    assert report.counts == {"retained_referenced": 1}
+    assert artifact.path.exists()
+
+
+def test_reference_publication_is_rejected_when_cleanup_wins_the_lock(
+    s13, tmp_path: Path
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "cleanup-first-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "unowned evidence",
+        "search",
+        summary="Cleanup removes this artifact before publication begins.",
+    ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    report = externalizer.cleanup_artifacts_from_journal(
+        journal,
+        policy=s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False),
+        now=now,
+    )
+    assert report.counts == {"deleted": 1}
+
+    publisher_called = False
+
+    def publisher() -> None:
+        nonlocal publisher_called
+        publisher_called = True
+
+    with pytest.raises(s13.ArtifactRetentionError, match="missing artifact"):
+        journal.publish_reference(
+            claim,
+            publisher,
+            transaction_id="too-late-reference",
+            prepared_at=now,
+        )
+    assert publisher_called is False
+    assert journal.recover(now=now).states == ()
+
+
+def test_cleanup_rejects_journal_owned_by_another_session(s13, tmp_path: Path) -> None:
+    externalizer = s13.ToolResultExternalizer(tmp_path / "cleanup-owner")
+    other_journal = s13.ArtifactRetentionJournal(tmp_path / "other-owner")
+    with pytest.raises(s13.ArtifactRetentionError, match="different artifact session"):
+        externalizer.plan_cleanup_from_journal(other_journal)
+
+
+def test_retention_journal_rejects_symlink_escape(s13, tmp_path: Path) -> None:
+    session_dir = tmp_path / "journal-symlink-session"
+    artifact = s13.ToolResultExternalizer(session_dir).externalize(
+        "owned artifact",
+        "search",
+        summary="The lease journal must remain in its session root.",
+    ).artifact
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
+    outside = tmp_path / "outside-journal.jsonl"
+    outside.write_text("outside owner\n", encoding="utf-8")
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    try:
+        journal.path.symlink_to(outside)
+    except OSError:
+        pytest.skip("file symlinks are unavailable on this platform")
+
+    with pytest.raises(s13.ArtifactLeaseJournalError, match="owned regular file"):
+        journal.prepare(
+            claim,
+            transaction_id="symlink-escape",
+        )
+    assert outside.read_text(encoding="utf-8") == "outside owner\n"


### PR DESCRIPTION
## Summary

- persist Artifact retention intents in an append-only, hash-chained per-session lease journal
- publish references through prepared/committed and remove them before released, retaining uncertain prepared intents after crashes
- recover and aggregate path-free claims across fresh processes while rejecting complete corruption, sequence gaps, tampering, cross-session records, and symlink escapes
- serialize journal writers and cleanup on POSIX and Windows; revalidate Artifact bytes before prepare and re-fold claims before delete
- reject raw-claim cleanup once a durable journal exists
- extend the layered Memory walkthrough, chapter documentation, and both architecture diagrams

## Validation

- Linux: `python3 -m pytest -q tests/test_output_externalization.py tests/test_layered_memory_walkthrough.py` (26 passed)
- Windows: `python -m pytest -q tests/test_output_externalization.py` (23 passed, 2 symlink-permission skips)
- full pytest suite passed locally except the workspace-shape image-count test affected by pre-existing untracked `tmp/` assets
- syntax, lesson interactivity, SVG XML, clean-room, public-doc, and image-specificity checks passed