### PR TITLE
fix(s13): retain leases for uncertain reference publication

### DIFF
--- a/s13_output_externalization/README.md
+++ b/s13_output_externalization/README.md
@@ -231,7 +231,9 @@ ArtifactMemoryReference
 3. COMMITTED ── append + fsync ──▶ 引用确认可见
 ```
 
-如果步骤 2 正常失败，Harness 追加 `ABORTED`。如果进程在步骤 1 后退出，无论 Memory 写入尚未发生、正在发生，还是已经成功但步骤 3 尚未执行，fresh journal 都把 `PREPARED` 恢复为无过期时间的保护性 claim，并把 transaction ID 放入 `pending_transaction_ids` 等待可信 adapter 对账。它宁可暂时多保留证据，也不会猜测引用不存在。
+步骤 2 的异常不等于“引用未写入”：Memory 可能已持久化引用，只是成功回执因超时或连接中断没有到达 Harness。`publish_reference()` 只在可信 adapter 抛出 `ArtifactPublicationRejected` 时追加 `ABORTED`；该类型必须保证**引用没有写入，且没有仍可能提交的在途写入**。不能依据异常消息、HTTP 状态码或模型输出直接推断这个保证。
+
+其他异常（包括 `TimeoutError`、`ConnectionError`、`OSError` 和普通 `RuntimeError`）原样传播，租约保持 `PREPARED`。进程在步骤 1 后退出也采用同样的恢复方式：无论 Memory 写入尚未发生、正在发生，还是已经成功但步骤 3 尚未执行，fresh journal 都把 `PREPARED` 恢复为无过期时间的保护性 claim，并把 transaction ID 放入 `pending_transaction_ids` 等待可信 adapter 对账。即使原 `retain_until` 和 orphan TTL 已过期，GC 仍会保留证据；这是待对账状态，不是永久完成状态。
 
 删除方向采用相反的安全顺序：先由 Memory adapter 删除引用，成功后才追加 `RELEASED`。`remove_reference()` 封装了这个顺序；若删除失败或进程先退出，committed lease 继续保护 Artifact。
 
@@ -252,7 +254,18 @@ journal.remove_reference(
 )
 ```
 
-`publish_reference()` 不会自动重放已有 transaction ID。看到已有 `PREPARED` 时，Harness 必须先查询 Memory owner 再显式 `commit()` 或 `abort()`；看到已有 `COMMITTED` 时也不能再次调用 publisher。这样重试不会把“不确定是否已经成功”变成重复 Memory 写入。
+publisher 成功返回必须表示引用已持久化。明确拒绝可以来自完全未发起写入的 adapter 校验，例如：
+
+```python
+def publish_validated_reference():
+    if not memory_adapter.accepts(memory_reference):
+        # 仅本地校验，尚未发起任何写入。
+        raise ArtifactPublicationRejected("reference rejected before write")
+    # 不把这里的普通异常转换成明确拒绝：写入结果可能已经不确定。
+    return memory_adapter.append(memory_reference)
+```
+
+`publish_reference()` 不会自动重放已有 transaction ID。看到已有 `PREPARED` 时，Harness 必须先向 Memory owner 对账：确认引用已持久化才显式 `commit()`；确认引用未发布、并排除在途写入后才显式 `abort()`。一次查询“未找到”本身不足以排除延迟提交或读视图滞后。看到已有 `COMMITTED` 时也不能再次调用 publisher。这样重试不会把“不确定是否已经成功”变成重复 Memory 写入。
 
 清理分成两个阶段：
 
@@ -507,7 +520,7 @@ if (resultSize > CODEBUDDY_TOOL_RESULT_THRESHOLD_KB * 1024) {
    - policy 显式控制 orphan TTL、最大删除数量和 dry-run
 
 4. **`ArtifactRetentionJournal` / `ArtifactLeaseRecovery`** — 可崩溃恢复的租约所有者
-   - `prepared → committed → released` 与 `prepared → aborted` 显式表达引用发布结果
+   - `prepared → committed → released` 表达成功发布与释放；仅确认未发布且不会再提交时才允许 `prepared → aborted`
    - sequence + hash chain 检查完整记录；只丢弃未换行的崩溃尾部
    - fresh instance fold journal；pending prepare 默认继续保护证据
 

--- a/s13_output_externalization/code.py
+++ b/s13_output_externalization/code.py
@@ -109,6 +109,13 @@ class ArtifactLeaseJournalError(RuntimeError):
     """A durable retention journal is corrupt or used out of phase."""
 
 
+class ArtifactPublicationRejected(RuntimeError):
+    """可信 Memory adapter 确认引用未写入，且没有仍可能提交的在途写入。
+
+    仅用于可证明的发布拒绝；超时、连接中断或普通异常不满足此契约。
+    """
+
+
 class ArtifactCleanupStatus(str, Enum):
     """Terminal or planned state for one artifact cleanup decision."""
 
@@ -1018,6 +1025,8 @@ class ArtifactRetentionJournal:
         *,
         aborted_at: datetime | None = None,
     ) -> ArtifactLeaseState:
+        """仅在可信 owner 确认引用未发布且不会再提交后，终止准备中的租约。"""
+
         return self._transition(
             transaction_id,
             ArtifactLeasePhase.ABORTED,
@@ -1033,7 +1042,11 @@ class ArtifactRetentionJournal:
         prepared_at: datetime | None = None,
         committed_at: datetime | None = None,
     ) -> tuple[ArtifactLeaseTransaction, _PublicationValue]:
-        """Prepare, invoke a Memory publisher, then commit its durable lease."""
+        """先准备租约，再发布引用；仅明确拒绝才 abort，不确定结果保持 PREPARED。
+
+        publisher 成功返回必须表示引用已持久化。普通异常原样传播，等待
+        Memory owner 对账；只有 ArtifactPublicationRejected 允许自动 abort。
+        """
 
         transaction, created = self._prepare(
             claim,
@@ -1046,7 +1059,7 @@ class ArtifactRetentionJournal:
             )
         try:
             value = publisher()
-        except Exception:
+        except ArtifactPublicationRejected:
             self.abort(transaction.transaction_id)
             raise
         self.commit(transaction.transaction_id, committed_at=committed_at)

--- a/tests/test_output_externalization.py
+++ b/tests/test_output_externalization.py
@@ -545,7 +545,85 @@ def test_expired_committed_lease_allows_orphan_collection(s13, tmp_path: Path) -
     assert not artifact.path.exists()
 
 
-def test_failed_reference_publication_aborts_lease(s13, tmp_path: Path) -> None:
+@pytest.mark.parametrize("error_type", [TimeoutError, ConnectionError, OSError, RuntimeError])
+@pytest.mark.parametrize("write_before_error", [False, True], ids=["before-write", "after-write"])
+def test_uncertain_publication_preserves_pending_lease_across_restart_and_gc(
+    s13, tmp_path: Path, error_type, write_before_error: bool
+) -> None:
+    now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
+    session_dir = tmp_path / "uncertain-publication-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        "evidence whose Memory publication result is uncertain",
+        "search",
+        summary="Publication acknowledgement may be lost after a durable write.",
+    ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(
+        artifact.for_memory(),
+        retain_until=(now - timedelta(hours=1)).isoformat(),
+    )
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    memory_path = tmp_path / "published-reference.json"
+    payload = artifact.for_memory().to_dict()
+    failure = error_type("publication result is unknown")
+    calls = []
+
+    def uncertain_publication() -> None:
+        calls.append("publish")
+        if write_before_error:
+            # 模拟 Memory 已持久化、但成功回执未到达 Harness 的边界。
+            with memory_path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, sort_keys=True)
+                handle.flush()
+                os.fsync(handle.fileno())
+        raise failure
+
+    with pytest.raises(error_type) as raised:
+        journal.publish_reference(
+            claim,
+            uncertain_publication,
+            transaction_id="uncertain-publication",
+            prepared_at=now - timedelta(hours=2),
+        )
+    assert raised.value is failure
+
+    restarted_journal = s13.ArtifactRetentionJournal(session_dir)
+    restarted_externalizer = s13.ToolResultExternalizer(session_dir)
+    recovery = restarted_journal.recover(now=now)
+    assert recovery.pending_transaction_ids == ("uncertain-publication",)
+    assert recovery.states[0].phases == (s13.ArtifactLeasePhase.PREPARED,)
+    assert len(recovery.claims) == 1
+    assert recovery.claims[0].source_id == artifact.source.source_id
+    assert recovery.claims[0].retain_until is None
+    if write_before_error:
+        assert json.loads(memory_path.read_text(encoding="utf-8")) == payload
+    else:
+        assert not memory_path.exists()
+
+    journal_before = restarted_journal.path.read_bytes()
+    with pytest.raises(s13.ArtifactLeaseJournalError, match="reconciliation"):
+        restarted_journal.publish_reference(
+            claim,
+            uncertain_publication,
+            transaction_id="uncertain-publication",
+        )
+    assert calls == ["publish"]
+    assert restarted_journal.path.read_bytes() == journal_before
+
+    # 即使原租约和 orphan TTL 均已到期，不确定结果仍必须保护证据。
+    report = restarted_externalizer.cleanup_artifacts_from_journal(
+        restarted_journal,
+        policy=s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False),
+        now=now,
+    )
+    assert report.counts == {"retained_referenced": 1}
+    assert artifact.path.exists()
+
+
+def test_explicitly_rejected_publication_aborts_lease_and_allows_gc(
+    s13, tmp_path: Path
+) -> None:
     now = datetime(2026, 8, 29, 12, tzinfo=timezone.utc)
     session_dir = tmp_path / "aborted-session"
     externalizer = s13.ToolResultExternalizer(session_dir)
@@ -554,23 +632,38 @@ def test_failed_reference_publication_aborts_lease(s13, tmp_path: Path) -> None:
         "search",
         summary="Reference publisher raises before commit.",
     ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
     claim = s13.ArtifactRetentionClaim.from_memory_reference(artifact.for_memory())
     journal = s13.ArtifactRetentionJournal(session_dir)
+    rejection = s13.ArtifactPublicationRejected("memory adapter rejected the write")
 
     def reject_publication() -> None:
-        raise RuntimeError("memory adapter rejected the write")
+        raise rejection
 
-    with pytest.raises(RuntimeError, match="rejected the write"):
+    with pytest.raises(s13.ArtifactPublicationRejected, match="rejected the write") as raised:
         journal.publish_reference(
             claim,
             reject_publication,
             transaction_id="aborted-publication",
             prepared_at=now,
         )
+    assert raised.value is rejection
 
-    recovery = s13.ArtifactRetentionJournal(session_dir).recover(now=now)
+    restarted_journal = s13.ArtifactRetentionJournal(session_dir)
+    recovery = restarted_journal.recover(now=now)
     assert recovery.claims == ()
-    assert recovery.states[0].current_phase is s13.ArtifactLeasePhase.ABORTED
+    assert recovery.pending_transaction_ids == ()
+    assert recovery.states[0].phases == (
+        s13.ArtifactLeasePhase.PREPARED,
+        s13.ArtifactLeasePhase.ABORTED,
+    )
+    report = s13.ToolResultExternalizer(session_dir).cleanup_artifacts_from_journal(
+        restarted_journal,
+        policy=s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False),
+        now=now,
+    )
+    assert report.counts == {"deleted": 1}
+    assert not artifact.path.exists()
 
 
 def test_post_fsync_commit_crash_recovers_and_retry_is_idempotent(


### PR DESCRIPTION
## Summary

- Fix a data-loss window where a Memory publisher could persist a reference and then raise (for example, a timeout while acknowledging the write), causing the retention journal to abort its protective lease.
- Add `ArtifactPublicationRejected` for a trusted adapter's explicit guarantee that no reference was written and no in-flight write can still commit. Only this result automatically transitions the lease to `ABORTED`.
- Propagate ordinary exceptions unchanged and preserve `PREPARED`, including restart recovery, unbounded pending protection, and refusal to replay a publisher without owner reconciliation.
- Update the S13 tutorial with the adapter contract and the distinction between confirmed rejection and an unknown outcome.

## Validation

- Eight regression cases (four exception types, before/after a durable reference write) failed before the fix and pass after it. They verify exception identity, fresh-instance recovery, retention past lease expiry/orphan TTL, and prevention of duplicate publication.
- Explicit rejection still aborts and permits orphan collection.
- Windows S13 suite: 31 passed, 2 platform-specific symlink tests skipped.
- WSL regression suite: 399 passed, 1 deselected. Only the image-reference test was excluded because pre-existing untracked local tmp images are outside the contribution; those files were preserved.
- Syntax, lesson interactivity, SVG XML, clean-room, and documentation/image specificity checks passed (SVG rasterization unavailable locally).
- CI runs the complete test suite and `scripts/verify.py` in a clean checkout on Python 3.10, 3.11, and 3.12.