### PR TITLE
feat(s13): reconcile pending artifact leases

### DIFF
--- a/examples/layered_memory_walkthrough/README.md
+++ b/examples/layered_memory_walkthrough/README.md
@@ -122,7 +122,7 @@ Manifest 只是一份验收报告，不是新的 Memory 真源。需要核验时
 - **重复不等于多存一份。** Workspace 用 evidence IDs 合并重复事实；User preference 用稳定 key 返回 `unchanged`。
 - **同一 state root 不等于同一用户。** Alice 和 Bob 的 scope digest 不同，不能互读 canonical state。
 - **引用不等于复制。** Memory-facing Artifact reference 没有 `content` 字段，大结果仍归 Artifact 文件所有。
-- **发布不等于立即可信。** lease intent 必须先于 Memory 引用落盘；重启遇到 pending prepare 时默认保留 Artifact，等待 owner 对账。
+- **发布不等于立即可信。** lease intent 必须先于 Memory 引用落盘；重启遇到 pending prepare 时默认保留 Artifact，等待 generation-fenced owner 对账。确认缺失时必须先在 owner 侧封存稳定 transaction ID、拒绝迟到写入，再把 lease 标成 `ABORTED`。
 - **清理不等于删除整个 session。** active claim 只按 source ID + 完整 digest 保护对应证据；达到 TTL 的无引用孤儿才能在重验后删除。
 - **恢复不等于复用旧对象。** walkthrough 明确创建 fresh store instances，再从磁盘重建视图。
 - **摘要不拥有事实。** S14 只压缩 messages 副本，source-bearing facts 和 pending items 单独渲染。

--- a/s13_output_externalization/README.md
+++ b/s13_output_externalization/README.md
@@ -20,6 +20,8 @@ flowchart LR
     F -. "later policy" .-> G["Memory Reference<br/>summary + pointer, no body"]
     G --> H["ArtifactRetentionClaim<br/>source ID + digest + lease"]
     H --> L["Lease Journal<br/>prepared → committed → released"]
+    L --> R["Owner Reconciliation<br/>generation fence + tombstone"]
+    R --> L
     C --> I["plan_cleanup → snapshot"]
     L --> I
     I --> J["retain referenced / recent<br/>delete expired orphan"]
@@ -38,6 +40,7 @@ flowchart LR
 - Memory 只能接收 `ArtifactMemoryReference`，保留必要摘要与可检索指针，不复制大结果正文。
 - 用无路径 `ArtifactRetentionClaim` 把 Memory 引用投影为清理租约；物理路径始终由 S13 的可信 session root 决定。
 - 在 Memory 发布引用前先把 lease intent 追加并 fsync 到 journal；重启后从 journal 恢复当前 claim view。
+- 用稳定 transaction ID 和 generation-fenced owner observation 对账 pending lease；不确定结果继续保护 Artifact。
 - 清理分成 plan/apply 两阶段，执行前重新核验文件 identity、mtime、大小与 SHA-256；变化时 fail-closed。
 - 模拟按需读取片段, 类似缺页中断。
 - 为 s14 的压缩减轻压力。
@@ -53,6 +56,7 @@ flowchart LR
 - 直接相信 Memory 中的 `artifact_path` 做删除，会把不可信持久化数据变成任意文件删除入口。
 - 先发布 Memory 引用、后记录进程内 claim，会在崩溃窗口里产生无法证明归属的 Artifact。
 - 删除 Memory 引用前先释放 lease，会在相反的崩溃窗口里留下仍可访问但已失去保护的指针。
+- 把一次“未找到”查询直接当成 `ABSENT`，会漏掉读取滞后、并发更新或迟到写入；缺失必须先在 owner 侧封存。
 - 扫描到未知文件、符号链接、digest 冲突或竞态仍继续删除，违背证据清理的 fail-closed 边界。
 
 ## 问题
@@ -265,7 +269,33 @@ def publish_validated_reference():
     return memory_adapter.append(memory_reference)
 ```
 
-`publish_reference()` 不会自动重放已有 transaction ID。看到已有 `PREPARED` 时，Harness 必须先向 Memory owner 对账：确认引用已持久化才显式 `commit()`；确认引用未发布、并排除在途写入后才显式 `abort()`。一次查询“未找到”本身不足以排除延迟提交或读视图滞后。看到已有 `COMMITTED` 时也不能再次调用 publisher。这样重试不会把“不确定是否已经成功”变成重复 Memory 写入。
+`publish_reference()` 不会自动重放已有 transaction ID。看到已有 `PREPARED` 时，Harness 必须先向 Memory owner 对账：确认引用已持久化才 `commit()`；确认引用未发布、并排除在途写入后才 `abort()`。一次查询“未找到”本身不足以排除延迟提交或读视图滞后。看到已有 `COMMITTED` 时也不能再次调用 publisher。这样重试不会把“不确定是否已经成功”变成重复 Memory 写入。
+
+#### Generation-fenced owner reconciliation
+
+`ArtifactReferenceOwner` 是 Memory adapter 必须实现的可信边界。`inspect_fenced(transaction)` 返回的 context manager 在整个裁决期间排除同一 transaction ID 的发布变化，并提供 `ArtifactReferenceObservation`：
+
+| owner observation | Harness 行为 | lease 结果 |
+|---|---|---|
+| `PUBLISHED`，source ID 与完整 digest 都匹配 | fence 内追加 `COMMITTED` | 引用按原租约保护 |
+| `PUBLISHED`，identity 不匹配 | 记录 `pending_conflict` | 保持 `PREPARED`，无限期保护 |
+| `UNKNOWN` | 记录 `pending_unknown` | 保持 `PREPARED`，等待重试 |
+| 未封存的 `ABSENT` | owner 先用 CAS 写 tombstone 并推进 generation | seal 成功后追加 `ABORTED` |
+| seal 前 generation 变化 | 记录 `pending_stale` | 保持 `PREPARED`，重新观察 |
+| 已封存的 `ABSENT` | 不重复 seal，直接完成 journal transition | 追加 `ABORTED` |
+
+缺失路径刻意采用 `owner tombstone → journal ABORTED` 的顺序。tombstone 必须永久拒绝这个稳定 transaction ID 的迟到写入和未来重放。如果进程在 tombstone fsync 后、journal append 前退出，Artifact 仍受 `PREPARED` 保护；重启后 owner 返回已封存的 absence，再安全完成 `ABORTED`。反过来先 abort 再封存，会重新打开“GC 已删除证据、迟到 Memory 引用随后可见”的窗口。
+
+```python
+# adapter 自己负责把数据库行版本、ETag 或对象 generation 映射为 fence。
+reports = journal.reconcile_pending(memory_owner_adapter)
+for report in reports:
+    audit_sink.append(report.to_dict())
+```
+
+`reconcile_pending()` 只处理调用开始时看到的 pending snapshot；并发新增的 prepare 留给下一轮。单条 `reconcile_reference()` 和 terminal report 都是幂等的：并发 reconciler 最多追加一个终态事件，后来者得到 `already_committed`、`already_aborted` 或 `already_released`。报告只包含 transaction ID、状态、原因和 generation，不携带物理路径、Memory 正文或凭证。
+
+这里不能由 S13 提供一个“适配所有 Memory”的默认实现：本地 JSONL、SQLite、远端数据库和对象存储的线性化点不同。具体 adapter 必须在真正的 Memory owner 内实现排他 fence、条件 tombstone 和稳定 publication ID；仅在客户端查询两次 generation 不能替代服务端 CAS 或事务。
 
 清理分成两个阶段：
 
@@ -524,20 +554,25 @@ if (resultSize > CODEBUDDY_TOOL_RESULT_THRESHOLD_KB * 1024) {
    - sequence + hash chain 检查完整记录；只丢弃未换行的崩溃尾部
    - fresh instance fold journal；pending prepare 默认继续保护证据
 
-5. **`ArtifactCleanupPlan` / `ArtifactCleanupReport`** — 两阶段、可审计清理
+5. **`ArtifactReferenceOwner` / `ArtifactReconciliationReport`** — generation-fenced Memory 对账
+   - owner fence 下核对稳定 transaction ID、source ID、完整 digest 与 generation
+   - 缺失先封存再 abort；unknown、conflict、stale 都保持 pending
+   - terminal retry 和并发 reconciler 幂等，报告不暴露路径或 Memory 正文
+
+6. **`ArtifactCleanupPlan` / `ArtifactCleanupReport`** — 两阶段、可审计清理
    - plan 冻结文件快照并解释每个 retain/delete 决策，不产生写操作
    - journal-aware apply 在同一排他锁内恢复 claims、重验 identity 与 digest
 
-6. **`MockLLM`** — 模拟 LLM 的行为
+7. **`MockLLM`** — 模拟 LLM 的行为
    - 按预设脚本生成工具调用
    - 看到外部化指针时，决定是否触发"缺页中断"（调 Read 读完整输出）
 
-7. **Agent 循环** — 集成外部化
+8. **Agent 循环** — 集成外部化
    - 工具执行后检查是否需要外部化
    - 需要则写 artifact + 生成结构化 reference + 替换上下文内容
    - 打印 `[externalize]` 日志，显示节省效果
 
-8. **Demo 场景** — 完整演示
+9. **Demo 场景** — 完整演示
    - 模拟一条产生 1.3MB 输出的 grep 命令
    - 展示外部化前后的上下文大小对比
    - 模拟 agent 需要完整输出时的缺页中断
@@ -567,7 +602,7 @@ python s13_output_externalization/code.py
 ## 练习
 
 1. 当前 `make_pointer` 保留 head 6KB + tail 24KB。如果 agent 最常需要的是输出的中间部分（比如第 40000 行的错误），怎么改进预览策略？提示：考虑基于正则匹配的关键行提取，或分块索引。
-2. 为 `pending_transaction_ids` 实现 owner reconciliation adapter：根据 Memory 中的稳定 reference ID 决定 `commit` 或 `abort`，并用 generation fence 证明对账期间的并发更新不会被旧结果覆盖。
+2. 为你使用的真实 Memory 数据库实现 `ArtifactReferenceOwner`：把数据库行版本、ETag 或对象 generation 映射成排他 fence，并证明 tombstone 能拒绝已经发出但尚未完成的迟到写入。
 3. 当前的 `should_externalize` 只看输出大小。如果一条命令的输出是 30KB 的随机字符串（对 agent 无用）vs 30KB 的结构化 JSON（每行都有用），应该用不同策略吗？思考：能否让外部化策略感知输出的信息密度？
 
 ---

--- a/s13_output_externalization/code.py
+++ b/s13_output_externalization/code.py
@@ -36,12 +36,12 @@ import re
 import tempfile
 import uuid
 from collections.abc import Callable, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 if os.name == "nt":
     import msvcrt
@@ -59,6 +59,7 @@ PROGRESSION = {
         "page-fault reads",
         "reference-aware artifact retention",
         "crash-recoverable retention lease journal",
+        "generation-fenced Memory owner reconciliation",
     ],
     "preserves": ["context budget mindset", "memory as a selective derived view"],
 }
@@ -116,6 +117,10 @@ class ArtifactPublicationRejected(RuntimeError):
     """
 
 
+class ArtifactOwnerGenerationChanged(RuntimeError):
+    """Memory owner generation changed before an absence proof could be sealed."""
+
+
 class ArtifactCleanupStatus(str, Enum):
     """Terminal or planned state for one artifact cleanup decision."""
 
@@ -139,6 +144,27 @@ class ArtifactLeasePhase(str, Enum):
     COMMITTED = "committed"
     RELEASED = "released"
     ABORTED = "aborted"
+
+
+class ArtifactReferencePresence(str, Enum):
+    """One fenced Memory-owner observation for a stable publication ID."""
+
+    PUBLISHED = "published"
+    ABSENT = "absent"
+    UNKNOWN = "unknown"
+
+
+class ArtifactReconciliationStatus(str, Enum):
+    """Auditable result of reconciling one durable lease transaction."""
+
+    COMMITTED = "committed"
+    ABORTED = "aborted"
+    PENDING_UNKNOWN = "pending_unknown"
+    PENDING_CONFLICT = "pending_conflict"
+    PENDING_STALE = "pending_stale"
+    ALREADY_COMMITTED = "already_committed"
+    ALREADY_ABORTED = "already_aborted"
+    ALREADY_RELEASED = "already_released"
 
 
 @dataclass(frozen=True)
@@ -583,6 +609,126 @@ class ArtifactLeaseRecovery:
         }
 
 
+@dataclass(frozen=True)
+class ArtifactReferenceObservation:
+    """Path-free Memory state captured while its generation fence is held.
+
+    ``absence_sealed`` means the owner has durably tombstoned this transaction
+    ID, so delayed or future writes for it can no longer become visible.
+    """
+
+    transaction_id: str
+    generation: int
+    presence: ArtifactReferencePresence
+    source_id: str | None = None
+    content_sha256: str | None = None
+    absence_sealed: bool = False
+
+    def __post_init__(self) -> None:
+        _source_component(self.transaction_id, field_name="lease transaction ID")
+        if (
+            isinstance(self.generation, bool)
+            or not isinstance(self.generation, int)
+            or self.generation < 0
+        ):
+            raise ArtifactRetentionError("owner generation must be a non-negative integer")
+        if not isinstance(self.presence, ArtifactReferencePresence):
+            raise ArtifactRetentionError("owner presence must use the typed enum")
+        if not isinstance(self.absence_sealed, bool):
+            raise ArtifactRetentionError("owner absence seal must be boolean")
+        if self.presence is ArtifactReferencePresence.PUBLISHED:
+            if not isinstance(self.source_id, str) or not isinstance(
+                self.content_sha256,
+                str,
+            ):
+                raise ArtifactRetentionError(
+                    "published owner observation requires source ID and digest"
+                )
+            parse_artifact_source_id(self.source_id)
+            if not _FULL_SHA256_PATTERN.fullmatch(self.content_sha256):
+                raise ArtifactRetentionError(
+                    "published owner observation requires a full SHA-256 digest"
+                )
+            if self.absence_sealed:
+                raise ArtifactRetentionError(
+                    "published owner observation cannot be sealed absent"
+                )
+            return
+        if self.source_id is not None or self.content_sha256 is not None:
+            raise ArtifactRetentionError(
+                "non-published owner observation cannot carry reference identity"
+            )
+        if (
+            self.presence is ArtifactReferencePresence.UNKNOWN
+            and self.absence_sealed
+        ):
+            raise ArtifactRetentionError("unknown owner observation cannot be sealed")
+
+
+class ArtifactReferenceFence(Protocol):
+    """Exclusive owner view that remains valid until its context exits."""
+
+    @property
+    def observation(self) -> ArtifactReferenceObservation:
+        """Return the owner state protected by this fence."""
+
+    def seal_absent(self) -> ArtifactReferenceObservation:
+        """CAS an unsealed absence into a durable tombstone and advance generation."""
+
+
+class ArtifactReferenceOwner(Protocol):
+    """Trusted Memory adapter for one stable publication transaction ID.
+
+    The context must exclude publication changes for the transaction while it
+    is held. A sealed absence must also reject delayed and future publication.
+    """
+
+    def inspect_fenced(
+        self,
+        transaction: ArtifactLeaseTransaction,
+    ) -> AbstractContextManager[ArtifactReferenceFence]:
+        """Observe the transaction while holding its owner generation fence."""
+
+
+@dataclass(frozen=True)
+class ArtifactReconciliationReport:
+    """Path-free reconciliation outcome suitable for logs and operator UI."""
+
+    transaction_id: str
+    status: ArtifactReconciliationStatus
+    reason: str
+    observed_generation: int | None = None
+
+    def __post_init__(self) -> None:
+        _source_component(self.transaction_id, field_name="lease transaction ID")
+        if not isinstance(self.status, ArtifactReconciliationStatus):
+            raise ArtifactRetentionError("reconciliation status must use the typed enum")
+        if (
+            not isinstance(self.reason, str)
+            or not self.reason
+            or len(self.reason) > 200
+        ):
+            raise ArtifactRetentionError(
+                "reconciliation reason must contain at most 200 characters"
+            )
+        if self.observed_generation is not None and (
+            isinstance(self.observed_generation, bool)
+            or not isinstance(self.observed_generation, int)
+            or self.observed_generation < 0
+        ):
+            raise ArtifactRetentionError(
+                "reconciliation generation must be a non-negative integer"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "transaction_id": self.transaction_id,
+            "status": self.status.value,
+            "reason": self.reason,
+            "observed_generation": self.observed_generation,
+        }
+
+
 class ArtifactRetentionJournal:
     """Crash-recoverable owner for Artifact retention leases.
 
@@ -981,19 +1127,231 @@ class ArtifactRetentionJournal:
                 )
             if state.current_phase is phase:
                 return state
-            self._validate_transition(state.current_phase, phase)
-            self._append_event_unlocked(
+            return self._transition_unlocked(
                 events,
-                state.transaction,
+                state,
                 phase,
                 recorded_at=recorded_at,
             )
-            updated = ArtifactLeaseState(
-                transaction=state.transaction,
-                phases=(*state.phases, phase),
+
+    def _transition_unlocked(
+        self,
+        events: Sequence[dict[str, object]],
+        state: ArtifactLeaseState,
+        phase: ArtifactLeasePhase,
+        *,
+        recorded_at: datetime | None = None,
+    ) -> ArtifactLeaseState:
+        """Append one transition while the caller holds the journal lock."""
+
+        self._validate_transition(state.current_phase, phase)
+        self._append_event_unlocked(
+            events,
+            state.transaction,
+            phase,
+            recorded_at=recorded_at,
+        )
+        updated = ArtifactLeaseState(
+            transaction=state.transaction,
+            phases=(*state.phases, phase),
+        )
+        self._checkpoint(f"after_{phase.value}")
+        return updated
+
+    @staticmethod
+    def _state_by_transaction_id(
+        states: Sequence[ArtifactLeaseState],
+        transaction_id: str,
+    ) -> ArtifactLeaseState | None:
+        return next(
+            (
+                state
+                for state in states
+                if state.transaction.transaction_id == transaction_id
+            ),
+            None,
+        )
+
+    @staticmethod
+    def _terminal_reconciliation_report(
+        state: ArtifactLeaseState,
+    ) -> ArtifactReconciliationReport | None:
+        statuses = {
+            ArtifactLeasePhase.COMMITTED: (
+                ArtifactReconciliationStatus.ALREADY_COMMITTED,
+                "lease_already_committed",
+            ),
+            ArtifactLeasePhase.ABORTED: (
+                ArtifactReconciliationStatus.ALREADY_ABORTED,
+                "lease_already_aborted",
+            ),
+            ArtifactLeasePhase.RELEASED: (
+                ArtifactReconciliationStatus.ALREADY_RELEASED,
+                "lease_already_released",
+            ),
+        }
+        result = statuses.get(state.current_phase)
+        if result is None:
+            return None
+        status, reason = result
+        return ArtifactReconciliationReport(
+            transaction_id=state.transaction.transaction_id,
+            status=status,
+            reason=reason,
+        )
+
+    def reconcile_reference(
+        self,
+        transaction_id: str,
+        owner: ArtifactReferenceOwner,
+        *,
+        resolved_at: datetime | None = None,
+    ) -> ArtifactReconciliationReport:
+        """Resolve one PREPARED lease while a trusted owner fence is held.
+
+        Presence must match the original source and digest. Absence is terminal
+        only after the owner durably seals the transaction ID against delayed
+        publication. Every other result remains conservatively PREPARED.
+        """
+
+        normalized_id = _source_component(
+            transaction_id,
+            field_name="lease transaction ID",
+        )
+        with _exclusive_journal_lock(self.path):
+            _events, states = self._read_states_unlocked()
+            state = self._state_by_transaction_id(states, normalized_id)
+            if state is None:
+                raise ArtifactLeaseJournalError(
+                    f"unknown lease transaction: {normalized_id}"
+                )
+            terminal = self._terminal_reconciliation_report(state)
+            if terminal is not None:
+                return terminal
+            transaction = state.transaction
+
+        # Memory I/O 不占用 journal lock；拿到 owner fence 后再重读 journal，
+        # 同时避免长时间查询阻塞 GC，也避免使用查询前的陈旧 lease 状态。
+        with owner.inspect_fenced(transaction) as fence:
+            observation = fence.observation
+            if not isinstance(observation, ArtifactReferenceObservation):
+                raise ArtifactRetentionError(
+                    "owner fence returned an invalid reference observation"
+                )
+            with _exclusive_journal_lock(self.path):
+                events, states = self._read_states_unlocked()
+                current = self._state_by_transaction_id(states, normalized_id)
+                if current is None:
+                    raise ArtifactLeaseJournalError(
+                        f"unknown lease transaction: {normalized_id}"
+                    )
+                terminal = self._terminal_reconciliation_report(current)
+                if terminal is not None:
+                    return terminal
+                if current.transaction != transaction:
+                    raise ArtifactLeaseJournalError(
+                        f"lease transaction {normalized_id} changed during reconciliation"
+                    )
+                if observation.transaction_id != normalized_id:
+                    return ArtifactReconciliationReport(
+                        transaction_id=normalized_id,
+                        status=ArtifactReconciliationStatus.PENDING_CONFLICT,
+                        reason="owner_transaction_mismatch",
+                        observed_generation=observation.generation,
+                    )
+                if observation.presence is ArtifactReferencePresence.UNKNOWN:
+                    return ArtifactReconciliationReport(
+                        transaction_id=normalized_id,
+                        status=ArtifactReconciliationStatus.PENDING_UNKNOWN,
+                        reason="owner_result_unknown",
+                        observed_generation=observation.generation,
+                    )
+                if observation.presence is ArtifactReferencePresence.PUBLISHED:
+                    claim = transaction.claim
+                    if (
+                        observation.source_id != claim.source_id
+                        or observation.content_sha256 != claim.content_sha256
+                    ):
+                        return ArtifactReconciliationReport(
+                            transaction_id=normalized_id,
+                            status=ArtifactReconciliationStatus.PENDING_CONFLICT,
+                            reason="owner_reference_mismatch",
+                            observed_generation=observation.generation,
+                        )
+                    self._transition_unlocked(
+                        events,
+                        current,
+                        ArtifactLeasePhase.COMMITTED,
+                        recorded_at=resolved_at,
+                    )
+                    return ArtifactReconciliationReport(
+                        transaction_id=normalized_id,
+                        status=ArtifactReconciliationStatus.COMMITTED,
+                        reason="owner_confirmed_reference",
+                        observed_generation=observation.generation,
+                    )
+
+                sealed = observation
+                if not sealed.absence_sealed:
+                    try:
+                        sealed = fence.seal_absent()
+                    except ArtifactOwnerGenerationChanged:
+                        return ArtifactReconciliationReport(
+                            transaction_id=normalized_id,
+                            status=ArtifactReconciliationStatus.PENDING_STALE,
+                            reason="owner_generation_changed",
+                            observed_generation=observation.generation,
+                        )
+                    if not isinstance(sealed, ArtifactReferenceObservation):
+                        raise ArtifactRetentionError(
+                            "owner fence returned an invalid sealed observation"
+                        )
+                    if sealed.generation <= observation.generation:
+                        raise ArtifactRetentionError(
+                            "sealing owner absence must advance its generation"
+                        )
+                if (
+                    sealed.transaction_id != normalized_id
+                    or sealed.presence is not ArtifactReferencePresence.ABSENT
+                    or not sealed.absence_sealed
+                ):
+                    return ArtifactReconciliationReport(
+                        transaction_id=normalized_id,
+                        status=ArtifactReconciliationStatus.PENDING_CONFLICT,
+                        reason="owner_absence_not_sealed",
+                        observed_generation=sealed.generation,
+                    )
+                self._checkpoint("after_owner_absence_sealed")
+                self._transition_unlocked(
+                    events,
+                    current,
+                    ArtifactLeasePhase.ABORTED,
+                    recorded_at=resolved_at,
+                )
+                return ArtifactReconciliationReport(
+                    transaction_id=normalized_id,
+                    status=ArtifactReconciliationStatus.ABORTED,
+                    reason="owner_sealed_absence",
+                    observed_generation=sealed.generation,
+                )
+
+    def reconcile_pending(
+        self,
+        owner: ArtifactReferenceOwner,
+        *,
+        resolved_at: datetime | None = None,
+    ) -> tuple[ArtifactReconciliationReport, ...]:
+        """Reconcile the pending snapshot; later prepares remain for the next run."""
+
+        pending = self.recover(now=resolved_at).pending_transaction_ids
+        return tuple(
+            self.reconcile_reference(
+                transaction_id,
+                owner,
+                resolved_at=resolved_at,
             )
-            self._checkpoint(f"after_{phase.value}")
-            return updated
+            for transaction_id in pending
+        )
 
     def commit(
         self,

--- a/tests/test_output_externalization.py
+++ b/tests/test_output_externalization.py
@@ -10,7 +10,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from threading import Barrier
+from threading import Barrier, RLock
 
 import pytest
 
@@ -30,6 +30,112 @@ def s13():
     spec.loader.exec_module(module)
     yield module
     sys.modules.pop(name, None)
+
+
+class _OwnerFence:
+    def __init__(self, owner, transaction, observation):
+        self.owner = owner
+        self.transaction = transaction
+        self._observation = observation
+
+    @property
+    def observation(self):
+        return self._observation
+
+    def seal_absent(self):
+        record = self.owner.records[self.transaction.transaction_id]
+        if self.owner.change_generation_before_seal:
+            record["generation"] += 1
+            self.owner.change_generation_before_seal = False
+            raise self.owner.s13.ArtifactOwnerGenerationChanged("owner changed")
+        if record["generation"] != self._observation.generation:
+            raise self.owner.s13.ArtifactOwnerGenerationChanged("owner changed")
+        if record["presence"] is not self.owner.s13.ArtifactReferencePresence.ABSENT:
+            raise self.owner.s13.ArtifactOwnerGenerationChanged("reference appeared")
+        record["generation"] += 1
+        record["absence_sealed"] = True
+        self._observation = self.owner._observation(self.transaction.transaction_id)
+        return self._observation
+
+
+class _OwnerFenceContext:
+    def __init__(self, owner, transaction):
+        self.owner = owner
+        self.transaction = transaction
+
+    def __enter__(self):
+        self.owner.lock.acquire()
+        self.owner.inspections += 1
+        self.owner.records.setdefault(
+            self.transaction.transaction_id,
+            {
+                "generation": 0,
+                "presence": self.owner.s13.ArtifactReferencePresence.ABSENT,
+                "source_id": None,
+                "content_sha256": None,
+                "absence_sealed": False,
+            },
+        )
+        return _OwnerFence(
+            self.owner,
+            self.transaction,
+            self.owner._observation(self.transaction.transaction_id),
+        )
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.owner.lock.release()
+        return False
+
+
+class _FakeReferenceOwner:
+    """用排他锁模拟远端 Memory 的 generation fence 与缺失 tombstone。"""
+
+    def __init__(self, s13):
+        self.s13 = s13
+        self.lock = RLock()
+        self.records = {}
+        self.inspections = 0
+        self.change_generation_before_seal = False
+
+    def _observation(self, transaction_id):
+        record = self.records[transaction_id]
+        return self.s13.ArtifactReferenceObservation(
+            transaction_id=transaction_id,
+            generation=record["generation"],
+            presence=record["presence"],
+            source_id=record["source_id"],
+            content_sha256=record["content_sha256"],
+            absence_sealed=record["absence_sealed"],
+        )
+
+    def inspect_fenced(self, transaction):
+        return _OwnerFenceContext(self, transaction)
+
+    def set_unknown(self, transaction_id):
+        with self.lock:
+            self.records[transaction_id] = {
+                "generation": 1,
+                "presence": self.s13.ArtifactReferencePresence.UNKNOWN,
+                "source_id": None,
+                "content_sha256": None,
+                "absence_sealed": False,
+            }
+
+    def publish(self, transaction_id, claim):
+        with self.lock:
+            current = self.records.get(transaction_id)
+            if current is not None and current["absence_sealed"]:
+                raise self.s13.ArtifactPublicationRejected(
+                    "owner tombstone rejects late publication"
+                )
+            generation = 1 if current is None else current["generation"] + 1
+            self.records[transaction_id] = {
+                "generation": generation,
+                "presence": self.s13.ArtifactReferencePresence.PUBLISHED,
+                "source_id": claim.source_id,
+                "content_sha256": claim.content_sha256,
+                "absence_sealed": False,
+            }
 
 
 def test_externalized_result_separates_body_pointer_and_reference(s13, tmp_path: Path) -> None:
@@ -135,6 +241,35 @@ def test_invalid_summary_fails_before_creating_artifact(s13, tmp_path: Path) -> 
 def _set_artifact_age(path: Path, *, now: datetime, age_seconds: int) -> None:
     observed = now.timestamp() - age_seconds
     os.utime(path, (observed, observed))
+
+
+def _prepare_pending_lease(
+    s13,
+    tmp_path: Path,
+    transaction_id: str,
+    *,
+    expired: bool = True,
+):
+    now = datetime(2026, 9, 1, 9, tzinfo=timezone.utc)
+    session_dir = tmp_path / f"{transaction_id}-session"
+    externalizer = s13.ToolResultExternalizer(session_dir)
+    artifact = externalizer.externalize(
+        f"reconciliation evidence for {transaction_id}",
+        "search",
+        summary="A pending Memory publication needs owner reconciliation.",
+    ).artifact
+    _set_artifact_age(artifact.path, now=now, age_seconds=7_200)
+    claim = s13.ArtifactRetentionClaim.from_memory_reference(
+        artifact.for_memory(),
+        retain_until=(now - timedelta(hours=1)).isoformat() if expired else None,
+    )
+    journal = s13.ArtifactRetentionJournal(session_dir)
+    journal.prepare(
+        claim,
+        transaction_id=transaction_id,
+        prepared_at=now - timedelta(hours=2),
+    )
+    return now, session_dir, externalizer, artifact, claim, journal
 
 
 def test_cleanup_retains_memory_reference_and_deletes_expired_orphan(
@@ -664,6 +799,206 @@ def test_explicitly_rejected_publication_aborts_lease_and_allows_gc(
     )
     assert report.counts == {"deleted": 1}
     assert not artifact.path.exists()
+
+
+def test_reconciliation_commits_exact_published_reference_after_restart_and_is_idempotent(
+    s13, tmp_path: Path
+) -> None:
+    now, session_dir, externalizer, artifact, claim, _journal = _prepare_pending_lease(
+        s13,
+        tmp_path,
+        "published-owner-reference",
+        expired=False,
+    )
+    owner = _FakeReferenceOwner(s13)
+    owner.publish("published-owner-reference", claim)
+
+    restarted = s13.ArtifactRetentionJournal(session_dir)
+    reports = restarted.reconcile_pending(
+        owner,
+        resolved_at=now,
+    )
+    assert len(reports) == 1
+    report = reports[0]
+    assert report.to_dict() == {
+        "transaction_id": "published-owner-reference",
+        "status": "committed",
+        "reason": "owner_confirmed_reference",
+        "observed_generation": 1,
+    }
+    recovery = s13.ArtifactRetentionJournal(session_dir).recover(now=now)
+    assert recovery.pending_transaction_ids == ()
+    assert recovery.states[0].current_phase is s13.ArtifactLeasePhase.COMMITTED
+
+    journal_before = restarted.path.read_bytes()
+    repeated = restarted.reconcile_reference("published-owner-reference", owner)
+    assert repeated.status is s13.ArtifactReconciliationStatus.ALREADY_COMMITTED
+    assert owner.inspections == 1
+    assert restarted.path.read_bytes() == journal_before
+
+    cleanup = externalizer.cleanup_artifacts_from_journal(
+        restarted,
+        policy=s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False),
+        now=now,
+    )
+    assert cleanup.counts == {"retained_referenced": 1}
+    assert artifact.path.exists()
+    assert str(tmp_path) not in json.dumps(report.to_dict(), sort_keys=True)
+
+
+def test_reconciliation_seals_absence_before_abort_and_rejects_late_publication(
+    s13, tmp_path: Path
+) -> None:
+    now, session_dir, externalizer, artifact, claim, journal = _prepare_pending_lease(
+        s13,
+        tmp_path,
+        "absent-owner-reference",
+    )
+    owner = _FakeReferenceOwner(s13)
+
+    report = journal.reconcile_reference(
+        "absent-owner-reference",
+        owner,
+        resolved_at=now,
+    )
+    assert report.status is s13.ArtifactReconciliationStatus.ABORTED
+    assert report.observed_generation == 1
+    assert owner.records["absent-owner-reference"]["absence_sealed"] is True
+    recovery = s13.ArtifactRetentionJournal(session_dir).recover(now=now)
+    assert recovery.pending_transaction_ids == ()
+    assert recovery.claims == ()
+    assert recovery.states[0].current_phase is s13.ArtifactLeasePhase.ABORTED
+
+    with pytest.raises(s13.ArtifactPublicationRejected, match="late publication"):
+        owner.publish("absent-owner-reference", claim)
+
+    cleanup = externalizer.cleanup_artifacts_from_journal(
+        journal,
+        policy=s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False),
+        now=now,
+    )
+    assert cleanup.counts == {"deleted": 1}
+    assert not artifact.path.exists()
+
+
+@pytest.mark.parametrize(
+    ("owner_setup", "expected_status", "expected_reason"),
+    [
+        ("unknown", "pending_unknown", "owner_result_unknown"),
+        ("mismatch", "pending_conflict", "owner_reference_mismatch"),
+        ("stale", "pending_stale", "owner_generation_changed"),
+    ],
+)
+def test_untrusted_or_stale_owner_result_remains_prepared_and_protects_gc(
+    s13,
+    tmp_path: Path,
+    owner_setup: str,
+    expected_status: str,
+    expected_reason: str,
+) -> None:
+    now, session_dir, externalizer, artifact, claim, journal = _prepare_pending_lease(
+        s13,
+        tmp_path,
+        f"{owner_setup}-owner-reference",
+    )
+    transaction_id = f"{owner_setup}-owner-reference"
+    owner = _FakeReferenceOwner(s13)
+    if owner_setup == "unknown":
+        owner.set_unknown(transaction_id)
+    elif owner_setup == "mismatch":
+        owner.publish(transaction_id, claim)
+        owner.records[transaction_id]["content_sha256"] = "f" * 64
+    else:
+        owner.change_generation_before_seal = True
+
+    report = journal.reconcile_reference(transaction_id, owner, resolved_at=now)
+    assert report.status.value == expected_status
+    assert report.reason == expected_reason
+    recovery = s13.ArtifactRetentionJournal(session_dir).recover(now=now)
+    assert recovery.pending_transaction_ids == (transaction_id,)
+    assert recovery.states[0].phases == (s13.ArtifactLeasePhase.PREPARED,)
+    assert recovery.claims[0].retain_until is None
+
+    cleanup = externalizer.cleanup_artifacts_from_journal(
+        journal,
+        policy=s13.ArtifactCleanupPolicy(orphan_ttl_seconds=60, dry_run=False),
+        now=now,
+    )
+    assert cleanup.counts == {"retained_referenced": 1}
+    assert artifact.path.exists()
+
+
+def test_crash_after_owner_seal_recovers_without_reopening_publication_window(
+    s13, tmp_path: Path, monkeypatch
+) -> None:
+    now, session_dir, _externalizer, _artifact, claim, journal = _prepare_pending_lease(
+        s13,
+        tmp_path,
+        "seal-crash-reference",
+    )
+    owner = _FakeReferenceOwner(s13)
+
+    def crash_after_seal(name: str) -> None:
+        if name == "after_owner_absence_sealed":
+            raise RuntimeError("simulated exit after owner tombstone fsync")
+
+    monkeypatch.setattr(journal, "_checkpoint", crash_after_seal)
+    with pytest.raises(RuntimeError, match="owner tombstone fsync"):
+        journal.reconcile_reference("seal-crash-reference", owner, resolved_at=now)
+
+    assert owner.records["seal-crash-reference"]["absence_sealed"] is True
+    restarted = s13.ArtifactRetentionJournal(session_dir)
+    assert restarted.recover(now=now).pending_transaction_ids == (
+        "seal-crash-reference",
+    )
+    with pytest.raises(s13.ArtifactPublicationRejected):
+        owner.publish("seal-crash-reference", claim)
+
+    report = restarted.reconcile_reference(
+        "seal-crash-reference",
+        owner,
+        resolved_at=now,
+    )
+    assert report.status is s13.ArtifactReconciliationStatus.ABORTED
+    assert report.observed_generation == 1
+    assert restarted.recover(now=now).pending_transaction_ids == ()
+
+
+def test_concurrent_reconciliation_appends_one_terminal_transition(
+    s13, tmp_path: Path
+) -> None:
+    now, session_dir, _externalizer, _artifact, claim, journal = _prepare_pending_lease(
+        s13,
+        tmp_path,
+        "concurrent-owner-reference",
+    )
+    owner = _FakeReferenceOwner(s13)
+    owner.publish("concurrent-owner-reference", claim)
+    barrier = Barrier(2)
+
+    def reconcile_once():
+        barrier.wait()
+        return journal.reconcile_reference(
+            "concurrent-owner-reference",
+            owner,
+            resolved_at=now,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        reports = list(executor.map(lambda _index: reconcile_once(), range(2)))
+
+    assert {report.status for report in reports} == {
+        s13.ArtifactReconciliationStatus.COMMITTED,
+        s13.ArtifactReconciliationStatus.ALREADY_COMMITTED,
+    }
+    records = [
+        json.loads(line)
+        for line in journal.path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["phase"] for record in records] == ["prepared", "committed"]
+    assert s13.ArtifactRetentionJournal(session_dir).recover(
+        now=now
+    ).pending_transaction_ids == ()
 
 
 def test_post_fsync_commit_crash_recovers_and_retry_is_idempotent(


### PR DESCRIPTION
## Summary

- Add a typed `ArtifactReferenceOwner` / `ArtifactReferenceFence` contract for reconciling crash-recovered `PREPARED` artifact leases against the real Memory owner.
- Confirm exact published references only when stable transaction ID, source ID, and full digest match under the owner generation fence.
- Resolve absence only after the owner CAS-seals the transaction ID with a durable tombstone that rejects delayed and future publication; unknown, conflicting, or stale observations remain conservatively `PREPARED`.
- Add idempotent single and batch reconciliation APIs plus path-free operator reports.
- Document the Memory ownership boundary and why a generic client-side double-read cannot replace a store-native generation fence/transaction.

## Safety properties covered

- `PUBLISHED` exact match -> `COMMITTED`.
- `ABSENT` -> owner tombstone first, then `ABORTED`.
- Unknown result, identity mismatch, or generation change -> no journal transition and GC protection remains unbounded.
- Crash after owner sealing but before journal append recovers safely without reopening the publication window.
- Concurrent reconcilers append at most one terminal transition; terminal retries do not call the owner again.
- Reconciliation reports expose no artifact path or Memory body.

## Validation

- `wsl.exe python3 -m pytest -o addopts= -q tests/test_output_externalization.py tests/test_layered_memory_walkthrough.py` -> 41 passed.
- Windows S13 suite passed; two platform-specific symlink tests skipped.
- Full local regression on latest upstream: 408 passed, 1 deselected. The only deselected test is the repository image-reference check because pre-existing untracked local `tmp/` images are outside this contribution and were preserved.
- Syntax, lesson interactivity, SVG XML, clean-room, public documentation specificity, and image specificity checks passed.
- CI runs the unmodified complete suite and `scripts/verify.py` in a clean checkout on Python 3.10, 3.11, and 3.12.