### PR TITLE
docs: add Awesome WorkBuddy reading resource

### DIFF
--- a/docs/further-reading.md
+++ b/docs/further-reading.md
@@ -33,6 +33,7 @@ This map turns a curated resource list into a reading path for this tutorial. Th
 | [Agent Client Protocol](https://agentclientprotocol.com) | UI/client to agent communication model. | s07, s24 |
 | [Claude Code Skills](https://docs.claude.com/en/docs/claude-code/skills) / [Agent Skills](https://www.anthropic.com/news/skills) | Skill packaging patterns. | s16 |
 | [datawhale: 如何写出好的 Skill](https://github.com/datawhalechina/hello-agents/blob/main/Extra-Chapter/Extra08-%E5%A6%82%E4%BD%95%E5%86%99%E5%87%BA%E5%A5%BD%E7%9A%84Skill.md) | Practical Chinese guide to writing skills. | s16 |
+| [Awesome WorkBuddy](https://github.com/sandbaseai/awesome-workbuddy) | Bilingual directory of WorkBuddy guides, Skills, MCP servers, and projects with license, provenance, permission, and data-flow review notes. | s16, s17, s23 |
 | [Skill survey: Evaluation and Evolution](https://arxiv.org/pdf/2606.11435) | 4 evolution paradigms, 6 benchmark families, SKILL-INJECT attack taxonomy. Local digest: [skill-evolution-and-evaluation.md](./skill-evolution-and-evaluation.md) | s16, s17, s23 |
 
 ## Memory Systems


### PR DESCRIPTION
## 变更描述

在 Further Reading Map 的 Tools, Skills, and Protocols 部分增加 Awesome WorkBuddy：它是双语、带许可证/来源/权限/数据流审核说明的 WorkBuddy 资料、Skills、MCP 和开源项目目录，适合作为 s16、s17、s23 的资源发现与安全复核入口。

关系披露：我是所链接目录的维护者。

## 变更类型

- [x] 其他：补充延伸阅读

## 涉及章节

- s16 Skills System
- s17 MCP Connectors
- s23 Audit Sandbox

## 检查清单

- [x] 没有引入新的外部依赖
- [x] 没有 hardcoded API key 或敏感信息
- [x] 已运行 `python3 -m pytest -q`（415 tests passed）
- [x] 已运行 `python3 scripts/verify.py`（all checks passed）
- [x] 已运行 `git diff --check`
- [x] 没有加入闭源代码、私有 prompt、未脱敏路径或产品内部细节