### PR TITLE
fix(s14): preserve tool protocol during compaction

### DIFF
--- a/examples/layered_memory_walkthrough/code.py
+++ b/examples/layered_memory_walkthrough/code.py
@@ -361,8 +361,18 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
         ),
     )
     messages = list(recovered_session["messages"])
-    messages.insert(
-        1,
+    messages[1:1] = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "walkthrough-tool-1",
+                    "name": "read_file",
+                    "input": {"path": "README.md"},
+                }
+            ],
+        },
         {
             "role": "user",
             "content": [
@@ -374,7 +384,7 @@ def run_walkthrough(home: Path) -> WalkthroughResult:
                 }
             ],
         },
-    )
+    ]
     for index in range(8):
         messages.append(
             {

--- a/s14_context_compact/README.md
+++ b/s14_context_compact/README.md
@@ -44,6 +44,7 @@ flowchart LR
 - 用 `SourcePointerResolver` 在可信根目录和授权策略内重新核验 Transcript / Artifact，而不是把 pointer 字符串当成证据。
 - 来源核验明确区分 `available`、`missing`、`denied`、`corrupt` 与 `unsupported`；只有 `available` 才能携带证据哈希。
 - `capture_retrieval_evidence()` 只冻结上游已经选中的 hit，不在压缩阶段重做 scope、score、冲突或预算裁决。
+- 用 `tool_use.id` / `tool_result.tool_use_id` 校验并原子裁剪工具交互，兼容同一消息中的并行调用。
 
 ## 常见误区
 
@@ -56,6 +57,8 @@ flowchart LR
 - 原地修改 messages 会连带污染 Transcript 回放或调用方保存的证据视图。
 - 摘要生成失败后仍用错误字符串替换旧历史，会静默丢失最后一份可用上下文。
 - 把压缩当成一定成功的操作，会让不可压缩的超长消息继续进入 provider 请求。
+- 只删重复的 `tool_result` 或只检查最近消息的第一个 block，会留下孤立调用并让 provider 拒绝整个请求。
+
 ## 问题
 
 agent 跑得越久，消息历史越长。一次对话可能产生几十条消息——每次工具调用的输入输出都堆在 `messages` 列表里。模型的上下文窗口是有限的（128K、200K，无论多大终归有限），一旦超限，API 直接报错。
@@ -73,7 +76,7 @@ agent 跑得越久，消息历史越长。一次对话可能产生几十条消�
 | 层级 | 策略 | 做什么 | 代价 |
 |------|------|-------|------|
 | Layer 1 | 工具结果截断 | 大输出截断为摘要 | 低（不丢消息） |
-| Layer 2 | 文件内容去重 | 同一文件多次读取 → 只留最新 | 低（不丢消息） |
+| Layer 2 | 文件内容去重 | 同一文件多次读取 → 只留最新 | 低（仅删除冗余交互） |
 | Layer 3 | 消息历史修剪 | 删除旧的非关键消息 | 中（可能丢细节） |
 | Layer 4 | 全对话摘要 | 用模型生成摘要替换历史 | 高（一次 API 调用） |
 
@@ -113,6 +116,8 @@ agent 跑得越久，消息历史越长。一次对话可能产生几十条消�
 ```
 
 **关键原则**：系统提示、工具定义与 `DurableContextState` **永远不进入有损压缩层**。压缩器先深拷贝 messages，四层只操作这份可丢弃 Prompt 视图；已确认事实、未决事项，以及已选 MemoryHit 的来源、分数、排名和冲突标记沿旁路进入下一次 API 调用。
+
+工具调用还有一条独立的不变量：每个非空 `tool_use.id` 必须唯一对应一个稍后出现的 `tool_result.tool_use_id`。压缩入口先用 `validate_tool_protocol()` 检查整张关联图；缺失、未知、重复或倒序 ID 都抛出 `ToolProtocolError`，即使消息尚未达到软阈值也不会把无效历史交给 provider。L2/L3/L4 删除内容时，把这对 block 当成一个原子 interaction group；并行工具调用仍可按各自 ID 独立保留。
 
 ### 压缩对象边界：Messages 可以有损，Durable state 必须无损
 
@@ -264,42 +269,34 @@ def truncate_tool_results(messages: list) -> list:
 同一个文件被读多次（agent 先读了全文，改了几行后又读了一次确认）——旧的读取结果是冗余的，只留最新的。
 
 ```python
-def dedup_file_reads(messages: list) -> list:
-    """Layer 2: 同一文件多次读取, 只保留最新一次。"""
-    # 找到每个文件路径最后一次读取的位置
-    last_read = {}  # path -> (msg_index, block_index)
-    for mi, msg in enumerate(messages):
-        content = msg.get("content")
-        if not isinstance(content, list):
-            continue
-        for bi, block in enumerate(content):
-            if (isinstance(block, dict)
-                and block.get("type") == "tool_result"
-                and block.get("_tool_name") == "read_file"):
-                path = block.get("_tool_input", {}).get("path", "")
-                last_read[path] = (mi, bi)
+def dedup_file_reads(messages: list) -> tuple[list, int]:
+    validate_tool_protocol(messages)
+    tool_results = [
+        block
+        for message in messages
+        if isinstance(message.get("content"), list)
+        for block in message["content"]
+        if isinstance(block, dict) and block.get("type") == "tool_result"
+    ]
+    latest_reads = {}  # path -> tool_use_id
+    for block in tool_results:
+        if block.get("_read_path"):
+            latest_reads[block["_read_path"]] = block["tool_use_id"]
 
-    # 删除非最新的文件读取结果
-    to_remove = set()
-    for path, (mi, bi) in last_read.items():
-        # 找所有更早的同文件读取
-        for mi2, msg in enumerate(messages[:mi]):
-            content = msg.get("content")
-            if not isinstance(content, list):
-                continue
-            for bi2, block in enumerate(content):
-                if (isinstance(block, dict)
-                    and block.get("type") == "tool_result"
-                    and block.get("_tool_name") == "read_file"
-                    and block.get("_tool_input", {}).get("path") == path):
-                    to_remove.add((mi2, bi2))
-
-    # 执行删除
-    for mi, bi in sorted(to_remove, reverse=True):
-        del messages[mi]["content"][bi]
-
-    return messages
+    obsolete_ids = {
+        block["tool_use_id"]
+        for block in tool_results
+        if block.get("_read_path")
+        and latest_reads[block["_read_path"]] != block["tool_use_id"]
+    }
+    # 按 ID 同时删除旧 tool_use 与旧 tool_result；同一消息中的
+    # 其他并行调用、结果和文本 block 不受影响。
+    old_count = estimate_tokens(messages)
+    deduplicated = _without_tool_interactions(messages, obsolete_ids)
+    return deduplicated, old_count - estimate_tokens(deduplicated)
 ```
+
+完整实现还会在删除后再次校验，并返回精确的 token 节省量；上面的片段突出所有权关系：`_read_path` 只判断“哪个文件读重复了”，`tool_use_id` 才决定“必须成对删除哪些协议 block”。
 
 ### Layer 3: 消息历史修剪
 
@@ -308,28 +305,23 @@ def dedup_file_reads(messages: list) -> list:
 ```python
 KEEP_RECENT_TURNS = 6  # 保留最近 6 轮
 
-def prune_old_messages(messages: list) -> list:
-    """Layer 3: 保留最近 N 轮, 删除旧消息。
-
-    注意: 不能删除中间的 tool_result 而留下 tool_use —
-    那会导致 API 报错。必须成对删除。
-    """
-    if len(messages) <= KEEP_RECENT_TURNS:
-        return messages
-
-    # 保留最近 N 条消息
-    kept = messages[-KEEP_RECENT_TURNS:]
-
-    # 确保不以孤立的 tool_result 开头
-    while kept and isinstance(kept[0].get("content"), list):
-        first = kept[0]["content"][0] if kept[0]["content"] else None
-        if isinstance(first, dict) and first.get("type") == "tool_result":
-            kept = kept[1:]
-        else:
-            break
-
-    return messages[:1] + kept  # 保留第一条用户消息作为上下文
+def prune_old_messages(messages: list) -> tuple[list, int]:
+    interactions = validate_tool_protocol(messages)
+    selected = {0, *range(len(messages) - KEEP_RECENT_TURNS, len(messages))}
+    crossing_ids = {
+        tool_id
+        for tool_id, pair in interactions.items()
+        if ((pair.tool_use_message in selected)
+            != (pair.tool_result_message in selected))
+    }
+    kept = [msg for index, msg in enumerate(messages) if index in selected]
+    # 跨越裁剪边界的一侧也被移除；混合消息中的普通文本仍保留。
+    old_count = estimate_tokens(messages)
+    pruned = _without_tool_interactions(kept, crossing_ids)
+    return pruned, old_count - estimate_tokens(pruned)
 ```
+
+只检查最近第一条消息的第一个 block 不够：一条消息可能先有文本、后有多个工具结果。这里检查的是所有 interaction 的两个消息索引，因此无论 block 顺序或并行数量如何，都不会留下半条调用链。
 
 ### Layer 4: 全对话摘要
 
@@ -337,13 +329,21 @@ def prune_old_messages(messages: list) -> list:
 
 ```python
 def generate_summary(messages: list, summarizer) -> tuple[list, int]:
-    """Layer 4: 生成对话摘要替换历史。
+    interactions = validate_tool_protocol(messages)
+    recent_start = len(messages) - 4
+    # 若固定边界切在 tool_use 与 result 之间，向前扩展到 tool_use。
+    while any(
+        pair.tool_use_message < recent_start <= pair.tool_result_message
+        for pair in interactions.values()
+    ):
+        recent_start = min(
+            pair.tool_use_message
+            for pair in interactions.values()
+            if pair.tool_use_message < recent_start <= pair.tool_result_message
+        )
 
-    调用模型总结到目前为止的对话,
-    用摘要替换旧消息, 保留最近几轮。
-    """
-    old_messages = messages[:-4]  # 保留最近 4 条
-    recent = messages[-4:]
+    old_messages = messages[:recent_start]
+    recent = messages[recent_start:]
 
     try:
         summary = summarizer(json.dumps(old_messages)).strip()
@@ -358,6 +358,8 @@ def generate_summary(messages: list, summarizer) -> tuple[list, int]:
     ] + recent
     return summarized, estimate_tokens(messages) - estimate_tokens(summarized)
 ```
+
+向前扩展可能让“最近窗口”超过四条消息，这是有意的：保留一条完整交互比机械满足消息条数更重要。如果扩展到索引 0、已经没有可总结的旧消息，或新视图并未真正变小，函数直接保留原视图。
 
 ### 在循环中的位置
 
@@ -439,7 +441,7 @@ selected hits ──capture_retrieval_evidence()──> immutable RetrievalEvide
 |--------|----------|------------|
 | token 计数 | 4 字符约 1 token | 使用目标模型 tokenizer，并计入 system 与 tools |
 | 工具结果 | 保留有界前缀 | 按内容类型保留头尾，或外置为 Artifact |
-| 协议完整性 | 避免以孤立 tool result 开头 | 按 tool-use ID 成对裁剪完整调用组 |
+| 协议完整性 | 全量校验 ID，并按 ID 原子裁剪调用组 | 补充 provider 专属的相邻角色、批量结果等语法约束 |
 | 摘要失败 | 原消息原样保留 | 加超时、重试预算和可观测失败原因 |
 | 长期事实 | durable state 旁路 | 接入带版本、冲突处理和来源校验的 Memory store |
 | source 核验 | 本地可信根、前置授权、结构与 digest 校验 | 对象存储 adapter、签名 manifest、细粒度租户策略与审计 trace |
@@ -466,12 +468,13 @@ S24 综合章直接复用本章的 `capture_retrieval_evidence()`、`DurableCont
 5. **`SourceResolution` / `resolve_durable_sources()`** — 用不可变五态结果冻结本轮观察，并按首次出现顺序去重
 6. **`render_durable_context()`** — 把 durable state 与核验状态独立渲染进 system context，不混入摘要或 excerpt
 7. **`estimate_tokens()`** — 粗略估算 messages 的 token 数（4 字符 ≈ 1 token）
-8. **`truncate_tool_results()`** — Layer 1: 截断超过 5000 token 的工具结果
-9. **`dedup_file_reads()`** — Layer 2: 同一文件多次读取，只留最新
-10. **`prune_old_messages()`** — Layer 3: 保留最近 N 轮，删除旧消息
-11. **`generate_summary()`** — Layer 4: 用模型生成摘要替换历史；失败或空摘要时保留原历史
-12. **`compact_context()`** — 深拷贝 messages，依次尝试四层，并返回 `CompactionResult`
-13. **Agent 循环** — 每次 API 调用前压缩 disposable messages、重新核验来源，再独立注入 durable state
+8. **`validate_tool_protocol()`** — 用唯一 ID 校验完整、正序的 tool-use/result 关联图
+9. **`truncate_tool_results()`** — Layer 1: 截断超过 5000 token 的工具结果
+10. **`dedup_file_reads()`** — Layer 2: 同一文件多次读取，只留最新的完整 interaction group
+11. **`prune_old_messages()`** — Layer 3: 保留最近 N 轮，原子移除跨边界工具交互
+12. **`generate_summary()`** — Layer 4: 在完整交互边界生成摘要；失败或空摘要时保留原历史
+13. **`compact_context()`** — 深拷贝 messages，先校验协议，再依次尝试四层并返回 `CompactionResult`
+14. **Agent 循环** — 每次 API 调用前压缩 disposable messages、重新核验来源，再独立注入 durable state
 
 运行后会看到压缩日志——每层触发时打印 `[compact]` 消息，可以看到哪些层在什么时候被触发。
 

--- a/s14_context_compact/code.py
+++ b/s14_context_compact/code.py
@@ -66,6 +66,7 @@ PROGRESSION = {
     "adds": [
         "token pressure detection",
         "structured compaction",
+        "protocol-safe tool interaction compaction",
         "hard message-view ceiling",
         "durable state preservation",
         "selected retrieval evidence retention",
@@ -880,6 +881,115 @@ def estimate_tokens(messages: list) -> int:
     return total
 
 
+class ToolProtocolError(ValueError):
+    """Raised when a prompt view contains an invalid tool interaction graph."""
+
+
+@dataclass(frozen=True)
+class _ToolInteraction:
+    """Locations of one complete provider tool-use/result interaction."""
+
+    tool_use_message: int
+    tool_result_message: int
+
+
+def _block_field(block: object, field: str, default: object = None) -> object:
+    """Read one field from mapping-shaped or SDK-shaped content blocks."""
+
+    if isinstance(block, dict):
+        return block.get(field, default)
+    return getattr(block, field, default)
+
+
+def _tool_block_id(block: object) -> tuple[str | None, object]:
+    """Return the protocol block type and its correlation ID, if applicable."""
+
+    block_type = _block_field(block, "type")
+    if block_type == "tool_use":
+        return "tool_use", _block_field(block, "id")
+    if block_type == "tool_result":
+        return "tool_result", _block_field(block, "tool_use_id")
+    return None, None
+
+
+def validate_tool_protocol(messages: list) -> dict[str, _ToolInteraction]:
+    """Validate and index complete tool interactions by correlation ID.
+
+    Compaction is allowed to lose evidence, but never to manufacture a
+    provider-invalid prompt. Each tool-use ID must therefore occur exactly
+    once on an assistant block and exactly once on a later user result block.
+    """
+
+    uses: dict[str, int] = {}
+    results: dict[str, int] = {}
+    for message_index, message in enumerate(messages):
+        role = message.get("role")
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            block_type, raw_id = _tool_block_id(block)
+            if block_type is None:
+                continue
+            if not isinstance(raw_id, str) or not raw_id.strip():
+                raise ToolProtocolError(f"{block_type} requires a non-empty correlation ID")
+            tool_id = raw_id
+            expected_role = "assistant" if block_type == "tool_use" else "user"
+            if role != expected_role:
+                raise ToolProtocolError(
+                    f"{block_type} {tool_id!r} must appear in a {expected_role} message"
+                )
+            locations = uses if block_type == "tool_use" else results
+            if tool_id in locations:
+                raise ToolProtocolError(f"duplicate {block_type} ID: {tool_id!r}")
+            locations[tool_id] = message_index
+
+    missing_results = sorted(set(uses) - set(results))
+    if missing_results:
+        raise ToolProtocolError(
+            f"tool_use has no matching tool_result: {missing_results[0]!r}"
+        )
+    unknown_results = sorted(set(results) - set(uses))
+    if unknown_results:
+        raise ToolProtocolError(
+            f"tool_result has no matching tool_use: {unknown_results[0]!r}"
+        )
+
+    interactions: dict[str, _ToolInteraction] = {}
+    for tool_id, use_message in uses.items():
+        result_message = results[tool_id]
+        if result_message <= use_message:
+            raise ToolProtocolError(
+                f"tool_result must follow tool_use for ID {tool_id!r}"
+            )
+        interactions[tool_id] = _ToolInteraction(use_message, result_message)
+    return interactions
+
+
+def _without_tool_interactions(messages: list, removed_ids: set[str]) -> list:
+    """Remove both sides of selected interactions and discard empty messages."""
+
+    if not removed_ids:
+        return messages
+    filtered: list = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            filtered.append(message)
+            continue
+        kept_blocks = []
+        for block in content:
+            block_type, raw_id = _tool_block_id(block)
+            if block_type is not None and raw_id in removed_ids:
+                continue
+            kept_blocks.append(block)
+        if kept_blocks:
+            copied_message = dict(message)
+            copied_message["content"] = kept_blocks
+            filtered.append(copied_message)
+    return filtered
+
+
 # ======================================================================
 # Layer 1: Tool result truncation
 # ======================================================================
@@ -892,6 +1002,7 @@ def truncate_tool_results(messages: list) -> tuple[list, int]:
 
     Returns: (modified messages, tokens saved)
     """
+    validate_tool_protocol(messages)
     saved = 0
     for msg in messages:
         if msg.get("role") != "user":
@@ -917,6 +1028,7 @@ def truncate_tool_results(messages: list) -> tuple[list, int]:
                 )
                 saved += tokens - MAX_TOOL_RESULT_TOKENS
 
+    validate_tool_protocol(messages)
     return messages, saved
 
 
@@ -933,12 +1045,11 @@ def dedup_file_reads(messages: list) -> tuple[list, int]:
 
     Returns: (modified messages, tokens saved)
     """
-    # Track metadata on tool results
-    # In real implementation, we'd correlate tool_use and tool_result
-    # by ID. Teaching version: we tag results during execution.
+    validate_tool_protocol(messages)
 
-    # Find the latest read of each file path
-    latest_reads: dict[str, int] = {}  # path -> msg index
+    # Find the latest completed read of each file path. ``_read_path`` is
+    # execution metadata, while ``tool_use_id`` is the protocol authority.
+    latest_reads: dict[str, str] = {}  # path -> tool-use ID
     for mi, msg in enumerate(messages):
         content = msg.get("content")
         if not isinstance(content, list):
@@ -948,30 +1059,29 @@ def dedup_file_reads(messages: list) -> tuple[list, int]:
                 continue
             if block.get("type") == "tool_result":
                 path = block.get("_read_path")
-                if path:
-                    latest_reads[path] = mi
+                tool_id = block.get("tool_use_id")
+                if path and isinstance(tool_id, str):
+                    latest_reads[path] = tool_id
 
-    # Remove older reads of the same file
-    saved = 0
-    for mi, msg in enumerate(messages):
+    # Mark older reads, then remove both their tool_use and tool_result blocks.
+    removed_ids: set[str] = set()
+    for msg in messages:
         content = msg.get("content")
         if not isinstance(content, list):
             continue
-        new_content = []
         for block in content:
             if not isinstance(block, dict):
-                new_content.append(block)
                 continue
             if block.get("type") == "tool_result":
                 path = block.get("_read_path")
-                if path and latest_reads.get(path, mi) > mi:
-                    # This is an older read — skip it
-                    saved += len(str(block.get("content", ""))) // 4
-                    continue
-            new_content.append(block)
-        msg["content"] = new_content
+                tool_id = block.get("tool_use_id")
+                if path and tool_id and latest_reads.get(path) != tool_id:
+                    removed_ids.add(tool_id)
 
-    return messages, saved
+    old_count = estimate_tokens(messages)
+    deduplicated = _without_tool_interactions(messages, removed_ids)
+    validate_tool_protocol(deduplicated)
+    return deduplicated, old_count - estimate_tokens(deduplicated)
 
 
 # ======================================================================
@@ -990,27 +1100,24 @@ def prune_old_messages(messages: list) -> tuple[list, int]:
 
     Returns: (pruned messages, tokens saved)
     """
+    interactions = validate_tool_protocol(messages)
     if len(messages) <= KEEP_RECENT_TURNS + 1:
         return messages, 0
 
     old_count = estimate_tokens(messages)
 
-    first = messages[0]
-    recent = messages[-KEEP_RECENT_TURNS:]
-
-    # Fix orphaned tool_results at the start of `recent`
-    while recent:
-        content = recent[0].get("content")
-        if not isinstance(content, list):
-            break
-        first_block = content[0] if content else None
-        if (isinstance(first_block, dict)
-                and first_block.get("type") == "tool_result"):
-            recent = recent[1:]
-        else:
-            break
-
-    pruned = [first] + recent
+    selected_indices = {0, *range(len(messages) - KEEP_RECENT_TURNS, len(messages))}
+    crossing_ids = {
+        tool_id
+        for tool_id, interaction in interactions.items()
+        if ((interaction.tool_use_message in selected_indices)
+            != (interaction.tool_result_message in selected_indices))
+    }
+    selected = [
+        message for index, message in enumerate(messages) if index in selected_indices
+    ]
+    pruned = _without_tool_interactions(selected, crossing_ids)
+    validate_tool_protocol(pruned)
     new_count = estimate_tokens(pruned)
 
     return pruned, old_count - new_count
@@ -1052,15 +1159,33 @@ def generate_summary(
 
     Returns: (summarized messages, tokens saved)
     """
+    interactions = validate_tool_protocol(messages)
     if len(messages) <= 4:
         return messages, 0
 
     old_count = estimate_tokens(messages)
 
-    # Split: old messages to summarize, recent to keep
+    # Split at a complete interaction boundary. If the raw four-message cut
+    # crosses a tool call, expand the recent window back to its tool_use.
     keep_recent = 4
-    to_summarize = messages[:-keep_recent]
-    recent = messages[-keep_recent:]
+    recent_start = len(messages) - keep_recent
+    while True:
+        expanded_start = min(
+            (
+                interaction.tool_use_message
+                for interaction in interactions.values()
+                if (interaction.tool_use_message < recent_start
+                    <= interaction.tool_result_message)
+            ),
+            default=recent_start,
+        )
+        if expanded_start == recent_start:
+            break
+        recent_start = expanded_start
+    if recent_start == 0:
+        return messages, 0
+    to_summarize = messages[:recent_start]
+    recent = messages[recent_start:]
 
     # Build a text representation of old messages for summarization
     convo_text = []
@@ -1074,16 +1199,28 @@ def generate_summary(
                     if block.get("type") == "text":
                         parts.append(block.get("text", ""))
                     elif block.get("type") == "tool_use":
-                        parts.append(f"[tool_use: {block.get('name', '?')}]")
+                        parts.append(
+                            f"[tool_use: {block.get('name', '?')} "
+                            f"id={block.get('id', '?')}]"
+                        )
                     elif block.get("type") == "tool_result":
-                        parts.append(f"[tool_result: {str(block.get('content', ''))[:200]}]")
+                        parts.append(
+                            f"[tool_result: id={block.get('tool_use_id', '?')} "
+                            f"{str(block.get('content', ''))[:200]}]"
+                        )
                 elif hasattr(block, 'type'):
                     if block.type == "text":
                         parts.append(block.text)
                     elif block.type == "tool_use":
-                        parts.append(f"[tool_use: {block.name}]")
+                        parts.append(
+                            f"[tool_use: {block.name} id={getattr(block, 'id', '?')}]"
+                        )
                     elif block.type == "tool_result":
-                        parts.append(f"[tool_result: {str(block.content)[:200]}]")
+                        parts.append(
+                            "[tool_result: "
+                            f"id={getattr(block, 'tool_use_id', '?')} "
+                            f"{str(block.content)[:200]}]"
+                        )
             content = " ".join(parts)
         convo_text.append(f"{role}: {content[:500]}")
 
@@ -1103,7 +1240,11 @@ def generate_summary(
         {"role": "assistant", "content": "好的, 我已了解之前的对话内容。请继续。"},
     ] + recent
 
+    validate_tool_protocol(summarized)
+
     new_count = estimate_tokens(summarized)
+    if new_count >= old_count:
+        return messages, 0
 
     return summarized, old_count - new_count
 
@@ -1132,6 +1273,7 @@ def compact_context(
     callers' transcript-derived messages unchanged for replay and audit.
     """
     working = copy.deepcopy(messages)
+    validate_tool_protocol(working)
     tokens_before = estimate_tokens(working)
     tokens = tokens_before
     applied_layers: list[str] = []

--- a/tests/test_context_compaction.py
+++ b/tests/test_context_compaction.py
@@ -9,6 +9,7 @@ import json
 import sys
 from dataclasses import FrozenInstanceError
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -77,10 +78,21 @@ def _long_messages() -> list[dict]:
         {"role": "user", "content": "Keep the original request."}
     ]
     for index in range(8):
+        content: str | list[dict] = f"turn-{index} " + ("detail " * 80)
+        if index == 0:
+            content = [
+                {"type": "text", "text": content},
+                {
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "read_file",
+                    "input": {"path": "src/app.py"},
+                },
+            ]
         messages.append(
             {
                 "role": "assistant" if index % 2 == 0 else "user",
-                "content": f"turn-{index} " + ("detail " * 80),
+                "content": content,
             }
         )
     messages.insert(
@@ -98,6 +110,50 @@ def _long_messages() -> list[dict]:
         },
     )
     return messages
+
+
+def _tool_ids(messages: list[dict]) -> tuple[list[str], list[str]]:
+    uses: list[str] = []
+    results: list[str] = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_use":
+                uses.append(block["id"])
+            elif block.get("type") == "tool_result":
+                results.append(block["tool_use_id"])
+    return uses, results
+
+
+def _file_read_interaction(tool_id: str, path: str, result: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": tool_id,
+                    "name": "read_file",
+                    "input": {"path": path},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_id,
+                    "content": result,
+                    "_read_path": path,
+                }
+            ],
+        },
+    ]
 
 
 def _source_fixture(s14, root: Path):
@@ -279,11 +335,243 @@ def test_failed_or_empty_summary_keeps_original_messages(s14) -> None:
         summarizer=lambda _: (_ for _ in ()).throw(RuntimeError("offline")),
     )
     empty, empty_saved = s14.generate_summary(messages, summarizer=lambda _: " ")
+    short_messages = [
+        {"role": "user" if index % 2 == 0 else "assistant", "content": str(index)}
+        for index in range(5)
+    ]
+    inflated, inflated_saved = s14.generate_summary(
+        short_messages, summarizer=lambda _: "longer summary " * 20
+    )
 
     assert failed is messages
     assert empty is messages
+    assert inflated is short_messages
     assert failed_saved == 0
     assert empty_saved == 0
+    assert inflated_saved == 0
+
+
+def test_file_read_dedup_removes_both_sides_and_preserves_parallel_tools(s14) -> None:
+    messages = [
+        {"role": "user", "content": "Inspect the workspace."},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "read-old",
+                    "name": "read_file",
+                    "input": {"path": "src/app.py"},
+                },
+                {
+                    "type": "tool_use",
+                    "id": "shell-1",
+                    "name": "run_command",
+                    "input": {"command": "git status"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "read-old",
+                    "content": "old file body " * 100,
+                    "_read_path": "src/app.py",
+                },
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "shell-1",
+                    "content": "clean",
+                },
+            ],
+        },
+        *_file_read_interaction("read-new", "src/app.py", "new file body"),
+    ]
+
+    deduplicated, saved = s14.dedup_file_reads(messages)
+
+    assert _tool_ids(deduplicated) == (
+        ["shell-1", "read-new"],
+        ["shell-1", "read-new"],
+    )
+    assert saved > 0
+    assert s14.validate_tool_protocol(deduplicated)
+
+
+def test_protocol_validation_accepts_sdk_shaped_tool_use_blocks(s14) -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                SimpleNamespace(
+                    type="tool_use",
+                    id="sdk-call",
+                    name="read_file",
+                    input={"path": "README.md"},
+                )
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "sdk-call",
+                    "content": "body",
+                    "_read_path": "README.md",
+                }
+            ],
+        },
+    ]
+
+    interactions = s14.validate_tool_protocol(messages)
+
+    assert set(interactions) == {"sdk-call"}
+
+
+def test_message_pruning_drops_an_entire_interaction_crossing_the_cut(
+    s14, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(s14, "KEEP_RECENT_TURNS", 2)
+    messages = [
+        {"role": "user", "content": "Keep the original request."},
+        {"role": "assistant", "content": "Old reasoning."},
+        {"role": "user", "content": "Old follow-up."},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "cut-call",
+                    "name": "read_file",
+                    "input": {"path": "README.md"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Keep this recent note."},
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "cut-call",
+                    "content": "result crossing the raw cut",
+                    "_read_path": "README.md",
+                },
+            ],
+        },
+        {"role": "assistant", "content": "Most recent answer."},
+    ]
+
+    pruned, saved = s14.prune_old_messages(messages)
+
+    assert _tool_ids(pruned) == ([], [])
+    assert "Keep this recent note." in str(pruned)
+    assert "Most recent answer." in str(pruned)
+    assert saved > 0
+    assert s14.validate_tool_protocol(pruned) == {}
+
+
+def test_summary_expands_recent_window_to_keep_a_complete_interaction(s14) -> None:
+    messages = [
+        {"role": "user", "content": "Original request."},
+        {"role": "assistant", "content": "Old answer details. " * 100},
+        *_file_read_interaction("boundary-call", "README.md", "current body"),
+        {"role": "assistant", "content": "Used the current body."},
+        {"role": "user", "content": "Continue."},
+        {"role": "assistant", "content": "Ready."},
+    ]
+    summary_inputs: list[str] = []
+
+    summarized, saved = s14.generate_summary(
+        messages,
+        summarizer=lambda conversation: summary_inputs.append(conversation) or "Old context.",
+    )
+
+    assert summary_inputs
+    assert "boundary-call" not in summary_inputs[0]
+    assert _tool_ids(summarized) == (["boundary-call"], ["boundary-call"])
+    assert saved > 0
+    assert s14.validate_tool_protocol(summarized)
+
+
+@pytest.mark.parametrize(
+    "messages, match",
+    [
+        (
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "missing", "name": "read_file"}
+                    ],
+                }
+            ],
+            "no matching tool_result",
+        ),
+        (
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "unknown",
+                            "content": "result",
+                        }
+                    ],
+                }
+            ],
+            "no matching tool_use",
+        ),
+        (
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "duplicate", "name": "read_file"}
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "duplicate", "content": "one"},
+                        {"type": "tool_result", "tool_use_id": "duplicate", "content": "two"},
+                    ],
+                },
+            ],
+            "duplicate tool_result ID",
+        ),
+        (
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "reversed", "content": "early"}
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "reversed", "name": "read_file"}
+                    ],
+                },
+            ],
+            "must follow tool_use",
+        ),
+    ],
+)
+def test_compaction_rejects_malformed_tool_protocol_without_mutating_input(
+    s14, messages: list[dict], match: str
+) -> None:
+    original = copy.deepcopy(messages)
+
+    with pytest.raises(s14.ToolProtocolError, match=match):
+        s14.compact_context(messages, verbose=False)
+
+    assert messages == original
 
 
 def test_source_pointer_parser_accepts_owned_shapes_and_rejects_paths(s14) -> None:


### PR DESCRIPTION
## Summary

- validate complete, unique, ordered `tool_use.id` / `tool_result.tool_use_id` pairs before provider admission
- remove file-read and pruning interactions atomically while preserving parallel blocks and mixed text
- move summary boundaries to keep complete tool interactions, with SDK-shaped block coverage
- update the layered Memory walkthrough to exercise a protocol-valid tool lifecycle

## Verification

- `462 passed, 1 deselected` in the full WSL suite (the deselected image-reference check only sees local untracked `tmp/` assets)
- `26 passed` for S14 and the layered Memory walkthrough
- syntax, lesson interactivity, SVG integrity, clean-room, public-doc specificity, and image-specificity checks all pass